### PR TITLE
added setting dadata url in bundle configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ class AppKernel extends Kernel
 velhron_dadata:
     token: 'token'
     secret: 'secret'
+    # Если у вас инфраструктура состоит из n-сервисов, которые обращаются в dadata, то для контроля запросов в dadata
+    # в одной точке, Вам возможно потребуется прокси-кеш. Для замены оригинальных url от dadata на Ваш прокси, можете
+    # заполнить следующие необязательные параметры
+    #base_general_url: 'https://proxy_dadata.ru/proxy/v2'
+    #base_cleaner_url: 'https://cleaner.proxy_dadata.ru/proxy/v1/clean'
+    #base_suggestions_url: 'https://suggestions.proxy_dadata.ru/suggestions/proxy/4_1/rs'
 ```
 
 ## Использование

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,7 +1,7 @@
 parameters:
     inferPrivatePropertyTypeFromConstructor: true
     checkMissingIterableValueType: false
-    level: 4
+    level: 7
     autoload_directories:
         - src
     paths:

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -20,6 +20,9 @@ class Configuration implements ConfigurationInterface
             ->children()
                 ->scalarNode('token')->end()
                 ->scalarNode('secret')->end()
+                ->scalarNode('base_general_url')->defaultValue('https://dadata.ru/api/v2')->end()
+                ->scalarNode('base_cleaner_url')->defaultValue('https://cleaner.dadata.ru/api/v1/clean')->end()
+                ->scalarNode('base_suggestions_url')->defaultValue('https://suggestions.dadata.ru/suggestions/api/4_1/rs')->end()
             ->end()
         ;
 

--- a/src/DependencyInjection/VelhronDadataExtension.php
+++ b/src/DependencyInjection/VelhronDadataExtension.php
@@ -19,7 +19,7 @@ class VelhronDadataExtension extends Extension
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
 
-        $loader = new YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
+        $loader = new YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yaml');
 
         $container->setParameter('velhron_dadata.token', $config['token']);

--- a/src/DependencyInjection/VelhronDadataExtension.php
+++ b/src/DependencyInjection/VelhronDadataExtension.php
@@ -19,10 +19,13 @@ class VelhronDadataExtension extends Extension
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
 
-        $loader = new YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader = new YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.yaml');
 
         $container->setParameter('velhron_dadata.token', $config['token']);
         $container->setParameter('velhron_dadata.secret', $config['secret']);
+        $container->setParameter('velhron_dadata.base_general_url', $config['base_general_url']);
+        $container->setParameter('velhron_dadata.base_cleaner_url', $config['base_cleaner_url']);
+        $container->setParameter('velhron_dadata.base_suggestions_url', $config['base_suggestions_url']);
     }
 }

--- a/src/Exception/InvalidConfigException.php
+++ b/src/Exception/InvalidConfigException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Velhron\DadataBundle\Exception;
 
 use Exception;

--- a/src/Exception/InvalidConfigException.php
+++ b/src/Exception/InvalidConfigException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Velhron\DadataBundle\Exception;
+
+use Exception;
+
+class InvalidConfigException extends Exception
+{
+}

--- a/src/Model/Request/AbstractRequest.php
+++ b/src/Model/Request/AbstractRequest.php
@@ -12,14 +12,14 @@ abstract class AbstractRequest
     protected $query;
 
     /**
-     * Базовый URL-адрес API.
+     * @var string URL запроса
      */
-    abstract protected function getBaseUrl(): string;
+    private $requestUrl;
 
-    /**
-     * Вызываемый метод API для URL.
-     */
-    abstract protected function getMethodUrl(): string;
+    public function __construct(string $url)
+    {
+        $this->requestUrl = $url;
+    }
 
     /**
      * Тело запроса.
@@ -35,7 +35,7 @@ abstract class AbstractRequest
 
     public function getUrl(): string
     {
-        return $this->getBaseUrl().$this->getMethodUrl();
+        return $this->requestUrl;
     }
 
     public function fillOptions(array $data): self

--- a/src/Model/Request/Clean/AddressRequest.php
+++ b/src/Model/Request/Clean/AddressRequest.php
@@ -6,11 +6,4 @@ namespace Velhron\DadataBundle\Model\Request\Clean;
 
 class AddressRequest extends CleanRequest
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function getMethodUrl(): string
-    {
-        return 'address';
-    }
 }

--- a/src/Model/Request/Clean/BirthdateRequest.php
+++ b/src/Model/Request/Clean/BirthdateRequest.php
@@ -6,11 +6,4 @@ namespace Velhron\DadataBundle\Model\Request\Clean;
 
 class BirthdateRequest extends CleanRequest
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function getMethodUrl(): string
-    {
-        return 'birthdate';
-    }
 }

--- a/src/Model/Request/Clean/CleanRequest.php
+++ b/src/Model/Request/Clean/CleanRequest.php
@@ -11,14 +11,6 @@ abstract class CleanRequest extends AbstractRequest
     /**
      * {@inheritdoc}
      */
-    public function getBaseUrl(): string
-    {
-        return 'https://cleaner.dadata.ru/api/v1/clean/';
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function getBody(): array
     {
         return [$this->query];

--- a/src/Model/Request/Clean/EmailRequest.php
+++ b/src/Model/Request/Clean/EmailRequest.php
@@ -6,11 +6,4 @@ namespace Velhron\DadataBundle\Model\Request\Clean;
 
 class EmailRequest extends CleanRequest
 {
-    /**
-     * {@inheritdoc}
-     */
-    protected function getMethodUrl(): string
-    {
-        return 'email';
-    }
 }

--- a/src/Model/Request/Clean/NameRequest.php
+++ b/src/Model/Request/Clean/NameRequest.php
@@ -6,11 +6,4 @@ namespace Velhron\DadataBundle\Model\Request\Clean;
 
 class NameRequest extends CleanRequest
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function getMethodUrl(): string
-    {
-        return 'name';
-    }
 }

--- a/src/Model/Request/Clean/PassportRequest.php
+++ b/src/Model/Request/Clean/PassportRequest.php
@@ -6,11 +6,4 @@ namespace Velhron\DadataBundle\Model\Request\Clean;
 
 class PassportRequest extends CleanRequest
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function getMethodUrl(): string
-    {
-        return 'passport';
-    }
 }

--- a/src/Model/Request/Clean/PhoneRequest.php
+++ b/src/Model/Request/Clean/PhoneRequest.php
@@ -6,11 +6,4 @@ namespace Velhron\DadataBundle\Model\Request\Clean;
 
 class PhoneRequest extends CleanRequest
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function getMethodUrl(): string
-    {
-        return 'phone';
-    }
 }

--- a/src/Model/Request/Clean/VehicleRequest.php
+++ b/src/Model/Request/Clean/VehicleRequest.php
@@ -6,11 +6,4 @@ namespace Velhron\DadataBundle\Model\Request\Clean;
 
 class VehicleRequest extends CleanRequest
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function getMethodUrl(): string
-    {
-        return 'vehicle';
-    }
 }

--- a/src/Model/Request/Find/AddressRequest.php
+++ b/src/Model/Request/Find/AddressRequest.php
@@ -10,12 +10,4 @@ class AddressRequest extends FindRequest
      * @var string На каком языке вернуть результат (ru / en)
      */
     protected $language;
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function getMethodUrl(): string
-    {
-        return 'address';
-    }
 }

--- a/src/Model/Request/Find/AffiliatedPartyRequest.php
+++ b/src/Model/Request/Find/AffiliatedPartyRequest.php
@@ -12,20 +12,4 @@ class AffiliatedPartyRequest extends SuggestRequest
      * @var string[] Ограничение области поиска (FOUNDERS / MANAGERS)
      */
     protected $scope;
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getBaseUrl(): string
-    {
-        return 'https://suggestions.dadata.ru/suggestions/api/4_1/rs/findAffiliated/';
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function getMethodUrl(): string
-    {
-        return 'party';
-    }
 }

--- a/src/Model/Request/Find/BankRequest.php
+++ b/src/Model/Request/Find/BankRequest.php
@@ -6,11 +6,4 @@ namespace Velhron\DadataBundle\Model\Request\Find;
 
 class BankRequest extends FindRequest
 {
-    /**
-     * {@inheritdoc}
-     */
-    protected function getMethodUrl(): string
-    {
-        return 'bank';
-    }
 }

--- a/src/Model/Request/Find/DeliveryRequest.php
+++ b/src/Model/Request/Find/DeliveryRequest.php
@@ -6,11 +6,4 @@ namespace Velhron\DadataBundle\Model\Request\Find;
 
 class DeliveryRequest extends FindRequest
 {
-    /**
-     * {@inheritdoc}
-     */
-    protected function getMethodUrl(): string
-    {
-        return 'delivery';
-    }
 }

--- a/src/Model/Request/Find/FiasRequest.php
+++ b/src/Model/Request/Find/FiasRequest.php
@@ -6,11 +6,4 @@ namespace Velhron\DadataBundle\Model\Request\Find;
 
 class FiasRequest extends FindRequest
 {
-    /**
-     * {@inheritdoc}
-     */
-    protected function getMethodUrl(): string
-    {
-        return 'fias';
-    }
 }

--- a/src/Model/Request/Find/FindRequest.php
+++ b/src/Model/Request/Find/FindRequest.php
@@ -8,11 +8,4 @@ use Velhron\DadataBundle\Model\Request\Suggest\SuggestRequest;
 
 abstract class FindRequest extends SuggestRequest
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function getBaseUrl(): string
-    {
-        return 'https://suggestions.dadata.ru/suggestions/api/4_1/rs/findById/';
-    }
 }

--- a/src/Model/Request/Find/PartyRequest.php
+++ b/src/Model/Request/Find/PartyRequest.php
@@ -20,12 +20,4 @@ class PartyRequest extends FindRequest
      * @var string Юр. лицо (LEGAL) или индивидуальный предприниматель (INDIVIDUAL)
      */
     protected $type;
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function getMethodUrl(): string
-    {
-        return 'party';
-    }
 }

--- a/src/Model/Request/Find/PostalUnitRequest.php
+++ b/src/Model/Request/Find/PostalUnitRequest.php
@@ -6,11 +6,4 @@ namespace Velhron\DadataBundle\Model\Request\Find;
 
 class PostalUnitRequest extends FindRequest
 {
-    /**
-     * {@inheritdoc}
-     */
-    protected function getMethodUrl(): string
-    {
-        return 'postal_unit';
-    }
 }

--- a/src/Model/Request/General/BalanceRequest.php
+++ b/src/Model/Request/General/BalanceRequest.php
@@ -6,11 +6,4 @@ namespace Velhron\DadataBundle\Model\Request\General;
 
 class BalanceRequest extends GeneralRequest
 {
-    /**
-     * {@inheritdoc}
-     */
-    protected function getMethodUrl(): string
-    {
-        return 'profile/balance';
-    }
 }

--- a/src/Model/Request/General/GeneralRequest.php
+++ b/src/Model/Request/General/GeneralRequest.php
@@ -11,14 +11,6 @@ abstract class GeneralRequest extends AbstractRequest
     /**
      * {@inheritdoc}
      */
-    protected function getBaseUrl(): string
-    {
-        return 'https://dadata.ru/api/v2/';
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function getBody(): array
     {
         return array_filter(get_object_vars($this), function ($var) {

--- a/src/Model/Request/General/StatRequest.php
+++ b/src/Model/Request/General/StatRequest.php
@@ -10,12 +10,4 @@ class StatRequest extends GeneralRequest
      * @var string Дата, за которую возвращается статистика
      */
     public $date;
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function getMethodUrl(): string
-    {
-        return 'stat/daily';
-    }
 }

--- a/src/Model/Request/General/VersionRequest.php
+++ b/src/Model/Request/General/VersionRequest.php
@@ -6,11 +6,4 @@ namespace Velhron\DadataBundle\Model\Request\General;
 
 class VersionRequest extends GeneralRequest
 {
-    /**
-     * {@inheritdoc}
-     */
-    protected function getMethodUrl(): string
-    {
-        return 'version';
-    }
 }

--- a/src/Model/Request/Geolocate/AddressRequest.php
+++ b/src/Model/Request/Geolocate/AddressRequest.php
@@ -10,12 +10,4 @@ class AddressRequest extends GeolocateRequest
      * @var string На каком языке вернуть результат (ru / en)
      */
     protected $language;
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getMethodUrl(): string
-    {
-        return 'address';
-    }
 }

--- a/src/Model/Request/Geolocate/GeolocateRequest.php
+++ b/src/Model/Request/Geolocate/GeolocateRequest.php
@@ -22,12 +22,4 @@ abstract class GeolocateRequest extends SuggestRequest
      * @var int Радиус поиска в метрах
      */
     protected $radius_meters;
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getBaseUrl(): string
-    {
-        return 'https://suggestions.dadata.ru/suggestions/api/4_1/rs/geolocate/';
-    }
 }

--- a/src/Model/Request/Geolocate/PostalUnitRequest.php
+++ b/src/Model/Request/Geolocate/PostalUnitRequest.php
@@ -6,11 +6,4 @@ namespace Velhron\DadataBundle\Model\Request\Geolocate;
 
 class PostalUnitRequest extends GeolocateRequest
 {
-    /**
-     * {@inheritdoc}
-     */
-    protected function getMethodUrl(): string
-    {
-        return 'postal_unit';
-    }
 }

--- a/src/Model/Request/Iplocate/AddressRequest.php
+++ b/src/Model/Request/Iplocate/AddressRequest.php
@@ -8,19 +8,4 @@ use Velhron\DadataBundle\Model\Request\Suggest\SuggestRequest;
 
 class AddressRequest extends SuggestRequest
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function getBaseUrl(): string
-    {
-        return 'https://suggestions.dadata.ru/suggestions/api/4_1/rs/iplocate/';
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getMethodUrl(): string
-    {
-        return 'address';
-    }
 }

--- a/src/Model/Request/Suggest/AddressRequest.php
+++ b/src/Model/Request/Suggest/AddressRequest.php
@@ -35,12 +35,4 @@ class AddressRequest extends SuggestRequest
      * @var array Гранулярные подсказки по адресу
      */
     protected $to_bound;
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getMethodUrl(): string
-    {
-        return 'address';
-    }
 }

--- a/src/Model/Request/Suggest/BankRequest.php
+++ b/src/Model/Request/Suggest/BankRequest.php
@@ -33,12 +33,4 @@ class BankRequest extends SuggestRequest
      * @var array Приоритет города при ранжировании
      */
     protected $locations_boost;
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getMethodUrl(): string
-    {
-        return 'bank';
-    }
 }

--- a/src/Model/Request/Suggest/CarBrandRequest.php
+++ b/src/Model/Request/Suggest/CarBrandRequest.php
@@ -6,11 +6,4 @@ namespace Velhron\DadataBundle\Model\Request\Suggest;
 
 class CarBrandRequest extends SuggestRequest
 {
-    /**
-     * {@inheritdoc}
-     */
-    protected function getMethodUrl(): string
-    {
-        return 'car_brand';
-    }
 }

--- a/src/Model/Request/Suggest/CountryRequest.php
+++ b/src/Model/Request/Suggest/CountryRequest.php
@@ -6,11 +6,4 @@ namespace Velhron\DadataBundle\Model\Request\Suggest;
 
 class CountryRequest extends SuggestRequest
 {
-    /**
-     * {@inheritdoc}
-     */
-    protected function getMethodUrl(): string
-    {
-        return 'country';
-    }
 }

--- a/src/Model/Request/Suggest/CurrencyRequest.php
+++ b/src/Model/Request/Suggest/CurrencyRequest.php
@@ -6,11 +6,4 @@ namespace Velhron\DadataBundle\Model\Request\Suggest;
 
 class CurrencyRequest extends SuggestRequest
 {
-    /**
-     * {@inheritdoc}
-     */
-    protected function getMethodUrl(): string
-    {
-        return 'currency';
-    }
 }

--- a/src/Model/Request/Suggest/EmailRequest.php
+++ b/src/Model/Request/Suggest/EmailRequest.php
@@ -6,11 +6,4 @@ namespace Velhron\DadataBundle\Model\Request\Suggest;
 
 class EmailRequest extends SuggestRequest
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function getMethodUrl(): string
-    {
-        return 'email';
-    }
 }

--- a/src/Model/Request/Suggest/FiasRequest.php
+++ b/src/Model/Request/Suggest/FiasRequest.php
@@ -25,12 +25,4 @@ class FiasRequest extends SuggestRequest
      * @var array Гранулярные подсказки по ФИАС
      */
     protected $to_bound;
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getMethodUrl(): string
-    {
-        return 'fias';
-    }
 }

--- a/src/Model/Request/Suggest/FioRequest.php
+++ b/src/Model/Request/Suggest/FioRequest.php
@@ -15,12 +15,4 @@ class FioRequest extends SuggestRequest
      * @var array Подсказки по части ФИО
      */
     protected $parts;
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getMethodUrl(): string
-    {
-        return 'fio';
-    }
 }

--- a/src/Model/Request/Suggest/FmsUnitRequest.php
+++ b/src/Model/Request/Suggest/FmsUnitRequest.php
@@ -10,12 +10,4 @@ class FmsUnitRequest extends SuggestRequest
      * @var array Фильтрация
      */
     public $filters;
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getMethodUrl(): string
-    {
-        return 'fms_unit';
-    }
 }

--- a/src/Model/Request/Suggest/FnsUnitRequest.php
+++ b/src/Model/Request/Suggest/FnsUnitRequest.php
@@ -10,12 +10,4 @@ class FnsUnitRequest extends SuggestRequest
      * @var array Фильтрация
      */
     public $filters;
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function getMethodUrl(): string
-    {
-        return 'fns_unit';
-    }
 }

--- a/src/Model/Request/Suggest/MetroRequest.php
+++ b/src/Model/Request/Suggest/MetroRequest.php
@@ -10,12 +10,4 @@ class MetroRequest extends SuggestRequest
      * @var array Фильтрация
      */
     public $filters;
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function getMethodUrl(): string
-    {
-        return 'metro';
-    }
 }

--- a/src/Model/Request/Suggest/Okpd2Request.php
+++ b/src/Model/Request/Suggest/Okpd2Request.php
@@ -10,12 +10,4 @@ class Okpd2Request extends SuggestRequest
      * @var array Фильтрация
      */
     public $filters;
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function getMethodUrl(): string
-    {
-        return 'okpd2';
-    }
 }

--- a/src/Model/Request/Suggest/Okved2Request.php
+++ b/src/Model/Request/Suggest/Okved2Request.php
@@ -10,12 +10,4 @@ class Okved2Request extends SuggestRequest
      * @var array Фильтрация
      */
     public $filters;
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function getMethodUrl(): string
-    {
-        return 'okved2';
-    }
 }

--- a/src/Model/Request/Suggest/PartyRequest.php
+++ b/src/Model/Request/Suggest/PartyRequest.php
@@ -25,12 +25,4 @@ class PartyRequest extends SuggestRequest
      * @var array Приоритет города при ранжировании
      */
     protected $locations_boost;
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getMethodUrl(): string
-    {
-        return 'party';
-    }
 }

--- a/src/Model/Request/Suggest/PostalUnitRequest.php
+++ b/src/Model/Request/Suggest/PostalUnitRequest.php
@@ -10,12 +10,4 @@ class PostalUnitRequest extends SuggestRequest
      * @var array Фильтрация
      */
     protected $filters;
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getMethodUrl(): string
-    {
-        return 'postal_unit';
-    }
 }

--- a/src/Model/Request/Suggest/RegionCourtRequest.php
+++ b/src/Model/Request/Suggest/RegionCourtRequest.php
@@ -10,12 +10,4 @@ class RegionCourtRequest extends SuggestRequest
      * @var array Фильтрация
      */
     protected $filters;
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function getMethodUrl(): string
-    {
-        return 'region_court';
-    }
 }

--- a/src/Model/Request/Suggest/SuggestRequest.php
+++ b/src/Model/Request/Suggest/SuggestRequest.php
@@ -16,14 +16,6 @@ abstract class SuggestRequest extends AbstractRequest
     /**
      * {@inheritdoc}
      */
-    public function getBaseUrl(): string
-    {
-        return 'https://suggestions.dadata.ru/suggestions/api/4_1/rs/suggest/';
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function getBody(): array
     {
         return array_filter(get_object_vars($this), function ($var) {

--- a/src/RequestFactory.php
+++ b/src/RequestFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Velhron\DadataBundle;
 
 use Velhron\DadataBundle\Exception\InvalidConfigException;
@@ -18,10 +20,6 @@ class RequestFactory
     }
 
     /**
-     * @param string $methodName
-     *
-     * @return AbstractRequest
-     *
      * @throws InvalidConfigException
      */
     public function create(string $methodName): AbstractRequest

--- a/src/RequestFactory.php
+++ b/src/RequestFactory.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Velhron\DadataBundle;
+
+use Velhron\DadataBundle\Exception\InvalidConfigException;
+use Velhron\DadataBundle\Model\Request\AbstractRequest;
+
+class RequestFactory
+{
+    /**
+     * @var Resolver
+     */
+    protected $resolver;
+
+    public function __construct(Resolver $resolver)
+    {
+        $this->resolver = $resolver;
+    }
+
+    /**
+     * @param string $methodName
+     *
+     * @return AbstractRequest
+     *
+     * @throws InvalidConfigException
+     */
+    public function create(string $methodName): AbstractRequest
+    {
+        $requestClass = $this->resolver->getMatchedRequest($methodName);
+
+        if (null === $requestClass) {
+            throw new InvalidConfigException("Для метода $methodName не указан параметр \"request\"");
+        }
+
+        $url = $this->resolver->getMatchedUrl($methodName);
+
+        if (null === $url) {
+            throw new InvalidConfigException("Для метода $methodName не указан параметр \"url\"");
+        }
+
+        return new $requestClass($url);
+    }
+}

--- a/src/Resolver.php
+++ b/src/Resolver.php
@@ -16,8 +16,6 @@ class Resolver
     /**
      * Resolver constructor.
      *
-     * @param array $methods
-     *
      * @throws InvalidConfigException
      */
     public function __construct(array $methods)
@@ -25,12 +23,12 @@ class Resolver
         foreach ($methods as $method) {
             if (isset($method['name'])) {
                 if (isset($this->methodsByName[$method['name']])) {
-                    throw new InvalidConfigException("Наименование метода должно быть уникально");
+                    throw new InvalidConfigException('Наименование метода должно быть уникально');
                 }
 
                 $this->methodsByName[$method['name']] = $method;
             } else {
-                throw new InvalidConfigException("Для одного из методов не указан параметр \"name\"");
+                throw new InvalidConfigException('Для одного из методов не указан параметр "name"');
             }
         }
     }

--- a/src/Resolver.php
+++ b/src/Resolver.php
@@ -4,33 +4,60 @@ declare(strict_types=1);
 
 namespace Velhron\DadataBundle;
 
+use Velhron\DadataBundle\Exception\InvalidConfigException;
+
 class Resolver
 {
-    private $methods;
+    /**
+     * @var array
+     */
+    private $methodsByName;
 
+    /**
+     * Resolver constructor.
+     *
+     * @param array $methods
+     *
+     * @throws InvalidConfigException
+     */
     public function __construct(array $methods)
     {
-        $this->methods = $methods;
+        foreach ($methods as $method) {
+            if (isset($method['name'])) {
+                if (isset($this->methodsByName[$method['name']])) {
+                    throw new InvalidConfigException("Наименование метода должно быть уникально");
+                }
+
+                $this->methodsByName[$method['name']] = $method;
+            } else {
+                throw new InvalidConfigException("Для одного из методов не указан параметр \"name\"");
+            }
+        }
     }
 
     public function getMatchedRequest(string $methodName): ?string
     {
         $method = $this->resolve($methodName);
 
-        return $method ? $method['request'] : null;
+        return isset($method, $method['request']) ? $method['request'] : null;
     }
 
     public function getMatchedResponse(string $methodName): ?string
     {
         $method = $this->resolve($methodName);
 
-        return $method ? $method['response'] : null;
+        return isset($method, $method['response']) ? $method['response'] : null;
+    }
+
+    public function getMatchedUrl(string $methodName): ?string
+    {
+        $method = $this->resolve($methodName);
+
+        return isset($method, $method['url']) ? $method['url'] : null;
     }
 
     public function resolve(string $methodName): ?array
     {
-        $key = array_search($methodName, array_column($this->methods, 'name'));
-
-        return false !== $key ? $this->methods[$key] : null;
+        return $this->methodsByName[$methodName] ?? null;
     }
 }

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -4,8 +4,9 @@ services:
     arguments:
       - '%velhron_dadata.token%'
       - '%velhron_dadata.secret%'
-      - '@Velhron\DadataBundle\Resolver'
       - '@http_client'
+      - '@Velhron\DadataBundle\RequestFactory'
+      - '@Velhron\DadataBundle\ResponseFactory'
 
   Velhron\DadataBundle\Service\DadataGeneral:
     parent: Velhron\DadataBundle\Service\AbstractService
@@ -22,6 +23,16 @@ services:
   Velhron\DadataBundle\Service\DadataGeolocate:
     parent: Velhron\DadataBundle\Service\AbstractService
 
+  Velhron\DadataBundle\RequestFactory:
+    public: true
+    arguments:
+      - '@Velhron\DadataBundle\Resolver'
+
+  Velhron\DadataBundle\ResponseFactory:
+    public: true
+    arguments:
+      - '@Velhron\DadataBundle\Resolver'
+
   Velhron\DadataBundle\Resolver:
     public: true
     arguments:
@@ -29,131 +40,176 @@ services:
         - name: 'suggestAddress'
           request: Velhron\DadataBundle\Model\Request\Suggest\AddressRequest
           response: Velhron\DadataBundle\Model\Response\Suggest\AddressResponse
+          url: '%velhron_dadata.base_suggestions_url%/suggest/address'
 
         - name: 'suggestParty'
           request: Velhron\DadataBundle\Model\Request\Suggest\PartyRequest
           response: Velhron\DadataBundle\Model\Response\Suggest\PartyResponse
+          url: '%velhron_dadata.base_suggestions_url%/suggest/party'
 
         - name: 'suggestBank'
           request: Velhron\DadataBundle\Model\Request\Suggest\BankRequest
           response: Velhron\DadataBundle\Model\Response\Suggest\BankResponse
+          url: '%velhron_dadata.base_suggestions_url%/suggest/bank'
 
         - name: 'suggestFio'
           request: Velhron\DadataBundle\Model\Request\Suggest\FioRequest
           response: Velhron\DadataBundle\Model\Response\Suggest\FioResponse
+          url: '%velhron_dadata.base_suggestions_url%/suggest/fio'
 
         - name: 'suggestEmail'
           request: Velhron\DadataBundle\Model\Request\Suggest\EmailRequest
           response: Velhron\DadataBundle\Model\Response\Suggest\EmailResponse
+          url: '%velhron_dadata.base_suggestions_url%/suggest/email'
 
         - name: 'suggestFias'
           request: Velhron\DadataBundle\Model\Request\Suggest\FiasRequest
           response: Velhron\DadataBundle\Model\Response\Suggest\AddressResponse
+          url: '%velhron_dadata.base_suggestions_url%/suggest/fias'
 
         - name: 'suggestFmsUnit'
           request: Velhron\DadataBundle\Model\Request\Suggest\FmsUnitRequest
           response: Velhron\DadataBundle\Model\Response\Suggest\FmsUnitResponse
+          url: '%velhron_dadata.base_suggestions_url%/suggest/fms_unit'
 
         - name: 'suggestPostalUnit'
           request: Velhron\DadataBundle\Model\Request\Suggest\PostalUnitRequest
           response: Velhron\DadataBundle\Model\Response\Suggest\PostalUnitResponse
+          url: '%velhron_dadata.base_suggestions_url%/suggest/postal_unit'
 
         - name: 'suggestFnsUnit'
           request: Velhron\DadataBundle\Model\Request\Suggest\FnsUnitRequest
           response: Velhron\DadataBundle\Model\Response\Suggest\FnsUnitResponse
+          url: '%velhron_dadata.base_suggestions_url%/suggest/fns_unit'
 
         - name: 'suggestRegionCourt'
           request: Velhron\DadataBundle\Model\Request\Suggest\RegionCourtRequest
           response: Velhron\DadataBundle\Model\Response\Suggest\RegionCourtResponse
+          url: '%velhron_dadata.base_suggestions_url%/suggest/region_court'
 
         - name: 'suggestMetro'
           request: Velhron\DadataBundle\Model\Request\Suggest\MetroRequest
           response: Velhron\DadataBundle\Model\Response\Suggest\MetroResponse
+          url: '%velhron_dadata.base_suggestions_url%/suggest/metro'
 
         - name: 'suggestCarBrand'
           request: Velhron\DadataBundle\Model\Request\Suggest\CarBrandRequest
           response: Velhron\DadataBundle\Model\Response\Suggest\CarBrandResponse
+          url: '%velhron_dadata.base_suggestions_url%/suggest/car_brand'
 
         - name: 'suggestCountry'
           request: Velhron\DadataBundle\Model\Request\Suggest\CountryRequest
           response: Velhron\DadataBundle\Model\Response\Suggest\CountryResponse
+          url: '%velhron_dadata.base_suggestions_url%/suggest/country'
 
         - name: 'suggestCurrency'
           request: Velhron\DadataBundle\Model\Request\Suggest\CurrencyRequest
           response: Velhron\DadataBundle\Model\Response\Suggest\CurrencyResponse
+          url: '%velhron_dadata.base_suggestions_url%/suggest/currency'
 
         - name: 'suggestOkved2'
           request: Velhron\DadataBundle\Model\Request\Suggest\Okved2Request
           response: Velhron\DadataBundle\Model\Response\Suggest\Okved2Response
+          url: '%velhron_dadata.base_suggestions_url%/suggest/okved2'
 
         - name: 'suggestOkpd2'
           request: Velhron\DadataBundle\Model\Request\Suggest\Okpd2Request
           response: Velhron\DadataBundle\Model\Response\Suggest\Okpd2Response
+          url: '%velhron_dadata.base_suggestions_url%/suggest/okpd2'
 
         - name: 'findAddress'
           request: Velhron\DadataBundle\Model\Request\Find\AddressRequest
           response: Velhron\DadataBundle\Model\Response\Suggest\AddressResponse
+          url: '%velhron_dadata.base_suggestions_url%/findById/address'
 
         - name: 'findPostalUnit'
           request: Velhron\DadataBundle\Model\Request\Find\PostalUnitRequest
           response: Velhron\DadataBundle\Model\Response\Suggest\PostalUnitResponse
+          url: '%velhron_dadata.base_suggestions_url%/findById/postal_unit'
 
         - name: 'findDelivery'
           request: Velhron\DadataBundle\Model\Request\Find\DeliveryRequest
           response: Velhron\DadataBundle\Model\Response\Find\DeliveryResponse
+          url: '%velhron_dadata.base_suggestions_url%/findById/delivery'
 
         - name: 'findParty'
           request: Velhron\DadataBundle\Model\Request\Find\PartyRequest
           response: Velhron\DadataBundle\Model\Response\Suggest\PartyResponse
+          url: '%velhron_dadata.base_suggestions_url%/findById/party'
 
         - name: 'findBank'
           request: Velhron\DadataBundle\Model\Request\Find\BankRequest
           response: Velhron\DadataBundle\Model\Response\Suggest\BankResponse
+          url: '%velhron_dadata.base_suggestions_url%/findById/bank'
 
         - name: 'findFias'
           request: Velhron\DadataBundle\Model\Request\Find\FiasRequest
           response: Velhron\DadataBundle\Model\Response\Suggest\AddressResponse
+          url: '%velhron_dadata.base_suggestions_url%/findById/fias'
 
         - name: 'findAffiliatedParty'
           request: Velhron\DadataBundle\Model\Request\Find\AffiliatedPartyRequest
           response: Velhron\DadataBundle\Model\Response\Find\AffiliatedPartyResponse
+          url: '%velhron_dadata.base_suggestions_url%/findAffiliated/party'
 
         - name: 'geolocateAddress'
           request: Velhron\DadataBundle\Model\Request\Geolocate\AddressRequest
           response: Velhron\DadataBundle\Model\Response\Suggest\AddressResponse
+          url: '%velhron_dadata.base_suggestions_url%/geolocate/address'
 
         - name: 'geolocatePostalUnit'
           request: Velhron\DadataBundle\Model\Request\Geolocate\PostalUnitRequest
           response: Velhron\DadataBundle\Model\Response\Suggest\PostalUnitResponse
+          url: '%velhron_dadata.base_suggestions_url%/geolocate/postal_unit'
 
         - name: 'iplocateAddress'
           request: Velhron\DadataBundle\Model\Request\Iplocate\AddressRequest
           response: Velhron\DadataBundle\Model\Response\Suggest\AddressResponse
+          url: '%velhron_dadata.base_suggestions_url%/iplocate/address'
 
         - name: 'cleanAddress'
           request: Velhron\DadataBundle\Model\Request\Clean\AddressRequest
           response: Velhron\DadataBundle\Model\Response\Clean\AddressResponse
+          url: '%velhron_dadata.base_cleaner_url%/address'
 
         - name: 'cleanPhone'
           request: Velhron\DadataBundle\Model\Request\Clean\PhoneRequest
           response: Velhron\DadataBundle\Model\Response\Clean\PhoneResponse
+          url: '%velhron_dadata.base_cleaner_url%/phone'
 
         - name: 'cleanPassport'
           request: Velhron\DadataBundle\Model\Request\Clean\PassportRequest
           response: Velhron\DadataBundle\Model\Response\Clean\PassportResponse
+          url: '%velhron_dadata.base_cleaner_url%/passport'
 
         - name: 'cleanBirthdate'
           request: Velhron\DadataBundle\Model\Request\Clean\BirthdateRequest
           response: Velhron\DadataBundle\Model\Response\Clean\BirthdateResponse
+          url: '%velhron_dadata.base_cleaner_url%/birthdate'
 
         - name: 'cleanVehicle'
           request: Velhron\DadataBundle\Model\Request\Clean\VehicleRequest
           response: Velhron\DadataBundle\Model\Response\Clean\VehicleResponse
+          url: '%velhron_dadata.base_cleaner_url%/vehicle'
 
         - name: 'cleanName'
           request: Velhron\DadataBundle\Model\Request\Clean\NameRequest
           response: Velhron\DadataBundle\Model\Response\Clean\NameResponse
+          url: '%velhron_dadata.base_cleaner_url%/name'
 
         - name: 'cleanEmail'
           request: Velhron\DadataBundle\Model\Request\Clean\EmailRequest
           response: Velhron\DadataBundle\Model\Response\Clean\EmailResponse
+          url: '%velhron_dadata.base_cleaner_url%/email'
+
+        - name: 'balance'
+          request: Velhron\DadataBundle\Model\Request\General\BalanceRequest
+          url: '%velhron_dadata.base_general_url%/profile/balance'
+
+        - name: 'stat'
+          request: Velhron\DadataBundle\Model\Request\General\StatRequest
+          url: '%velhron_dadata.base_general_url%/stat/daily'
+
+        - name: 'version'
+          request: Velhron\DadataBundle\Model\Request\General\VersionRequest
+          url: '%velhron_dadata.base_general_url%/version'

--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Velhron\DadataBundle;
+
+use Velhron\DadataBundle\Exception\InvalidConfigException;
+use Velhron\DadataBundle\Model\Response\AbstractResponse;
+
+class ResponseFactory
+{
+    /**
+     * @var Resolver
+     */
+    protected $resolver;
+
+    public function __construct(Resolver $resolver)
+    {
+        $this->resolver = $resolver;
+    }
+
+    /**
+     * @param string $methodName
+     * @param array  $data
+     *
+     * @return AbstractResponse
+     *
+     * @throws InvalidConfigException
+     */
+    public function create(string $methodName, array $data): AbstractResponse
+    {
+        $responseClass = $this->resolver->getMatchedResponse($methodName);
+
+        if (null === $responseClass) {
+            throw new InvalidConfigException("Для метода $methodName не указан параметр \"response\"");
+        }
+
+        return new $responseClass($data);
+    }
+}

--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Velhron\DadataBundle;
 
 use Velhron\DadataBundle\Exception\InvalidConfigException;
@@ -18,11 +20,6 @@ class ResponseFactory
     }
 
     /**
-     * @param string $methodName
-     * @param array  $data
-     *
-     * @return AbstractResponse
-     *
      * @throws InvalidConfigException
      */
     public function create(string $methodName, array $data): AbstractResponse

--- a/src/Service/AbstractService.php
+++ b/src/Service/AbstractService.php
@@ -52,10 +52,6 @@ abstract class AbstractService
     }
 
     /**
-     * @param AbstractRequest $request
-     *
-     * @return array
-     *
      * @throws DadataException
      */
     abstract protected function query(AbstractRequest $request): array;

--- a/src/Service/AbstractService.php
+++ b/src/Service/AbstractService.php
@@ -7,7 +7,8 @@ namespace Velhron\DadataBundle\Service;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Velhron\DadataBundle\Exception\DadataException;
 use Velhron\DadataBundle\Model\Request\AbstractRequest;
-use Velhron\DadataBundle\Resolver;
+use Velhron\DadataBundle\RequestFactory;
+use Velhron\DadataBundle\ResponseFactory;
 
 abstract class AbstractService
 {
@@ -22,24 +23,39 @@ abstract class AbstractService
     protected $secret;
 
     /**
-     * @var Resolver
-     */
-    protected $resolver;
-
-    /**
      * @var HttpClientInterface HTTP-клиент
      */
     protected $httpClient;
 
-    public function __construct(string $token, string $secret, Resolver $resolver, HttpClientInterface $httpClient)
-    {
+    /**
+     * @var RequestFactory
+     */
+    protected $requestFactory;
+
+    /**
+     * @var ResponseFactory
+     */
+    protected $responseFactory;
+
+    public function __construct(
+        string $token,
+        string $secret,
+        HttpClientInterface $httpClient,
+        RequestFactory $requestFactory,
+        ResponseFactory $responseFactory
+    ) {
         $this->token = $token;
         $this->secret = $secret;
-        $this->resolver = $resolver;
         $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->responseFactory = $responseFactory;
     }
 
     /**
+     * @param AbstractRequest $request
+     *
+     * @return array
+     *
      * @throws DadataException
      */
     abstract protected function query(AbstractRequest $request): array;

--- a/src/Service/DadataClean.php
+++ b/src/Service/DadataClean.php
@@ -23,11 +23,6 @@ class DadataClean extends AbstractService
     /**
      * Обработчик для API стандартизации.
      *
-     * @param string $method
-     * @param string $query
-     *
-     * @return AbstractResponse
-     *
      * @throws DadataException|InvalidConfigException
      */
     private function handle(string $method, string $query): AbstractResponse

--- a/src/Service/DadataClean.php
+++ b/src/Service/DadataClean.php
@@ -6,8 +6,10 @@ namespace Velhron\DadataBundle\Service;
 
 use Symfony\Contracts\HttpClient\Exception\ExceptionInterface;
 use Velhron\DadataBundle\Exception\DadataException;
+use Velhron\DadataBundle\Exception\InvalidConfigException;
 use Velhron\DadataBundle\Model\Request\AbstractRequest;
 use Velhron\DadataBundle\Model\Request\Clean\CleanRequest;
+use Velhron\DadataBundle\Model\Response\AbstractResponse;
 use Velhron\DadataBundle\Model\Response\Clean\AddressResponse;
 use Velhron\DadataBundle\Model\Response\Clean\BirthdateResponse;
 use Velhron\DadataBundle\Model\Response\Clean\EmailResponse;
@@ -21,20 +23,22 @@ class DadataClean extends AbstractService
     /**
      * Обработчик для API стандартизации.
      *
-     * @throws DadataException
+     * @param string $method
+     * @param string $query
+     *
+     * @return AbstractResponse
+     *
+     * @throws DadataException|InvalidConfigException
      */
-    private function handle(string $method, string $query)
+    private function handle(string $method, string $query): AbstractResponse
     {
-        $requestClass = $this->resolver->getMatchedRequest($method);
-        $responseClass = $this->resolver->getMatchedResponse($method);
-
         /* @var CleanRequest $request */
-        $request = new $requestClass();
+        $request = $this->requestFactory->create($method);
         $request->setQuery($query);
 
         $responseData = $this->query($request);
 
-        return new $responseClass($responseData);
+        return $this->responseFactory->create($method, $responseData);
     }
 
     /**
@@ -72,11 +76,14 @@ class DadataClean extends AbstractService
      *
      * @return AddressResponse Стандартизованный объект
      *
-     * @throws DadataException
+     * @throws DadataException|InvalidConfigException
      */
     public function cleanAddress(string $query): AddressResponse
     {
-        return $this->handle('cleanAddress', $query);
+        /** @var AddressResponse $response */
+        $response = $this->handle('cleanAddress', $query);
+
+        return $response;
     }
 
     /**
@@ -89,11 +96,14 @@ class DadataClean extends AbstractService
      *
      * @return PhoneResponse Стандартизованный объект
      *
-     * @throws DadataException
+     * @throws DadataException|InvalidConfigException
      */
     public function cleanPhone(string $query): PhoneResponse
     {
-        return $this->handle('cleanPhone', $query);
+        /** @var PhoneResponse $response */
+        $response = $this->handle('cleanPhone', $query);
+
+        return $response;
     }
 
     /**
@@ -105,11 +115,14 @@ class DadataClean extends AbstractService
      *
      * @return PassportResponse Стандартизованный объект
      *
-     * @throws DadataException
+     * @throws DadataException|InvalidConfigException
      */
     public function cleanPassport(string $query): PassportResponse
     {
-        return $this->handle('cleanPassport', $query);
+        /** @var PassportResponse $response */
+        $response = $this->handle('cleanPassport', $query);
+
+        return $response;
     }
 
     /**
@@ -119,11 +132,14 @@ class DadataClean extends AbstractService
      *
      * @return BirthdateResponse Стандартизованный объект
      *
-     * @throws DadataException
+     * @throws DadataException|InvalidConfigException
      */
     public function cleanBirthdate(string $query): BirthdateResponse
     {
-        return $this->handle('cleanBirthdate', $query);
+        /** @var BirthdateResponse $response */
+        $response = $this->handle('cleanBirthdate', $query);
+
+        return $response;
     }
 
     /**
@@ -133,11 +149,14 @@ class DadataClean extends AbstractService
      *
      * @return VehicleResponse Стандартизованный объект
      *
-     * @throws DadataException
+     * @throws DadataException|InvalidConfigException
      */
     public function cleanVehicle(string $query): VehicleResponse
     {
-        return $this->handle('cleanVehicle', $query);
+        /** @var VehicleResponse $response */
+        $response = $this->handle('cleanVehicle', $query);
+
+        return $response;
     }
 
     /**
@@ -149,11 +168,14 @@ class DadataClean extends AbstractService
      *
      * @return NameResponse Стандартизованный объект
      *
-     * @throws DadataException
+     * @throws DadataException|InvalidConfigException
      */
     public function cleanName(string $query): NameResponse
     {
-        return $this->handle('cleanName', $query);
+        /** @var NameResponse $response */
+        $response = $this->handle('cleanName', $query);
+
+        return $response;
     }
 
     /**
@@ -166,10 +188,13 @@ class DadataClean extends AbstractService
      *
      * @return EmailResponse Стандартизованный объект
      *
-     * @throws DadataException
+     * @throws DadataException|InvalidConfigException
      */
     public function cleanEmail(string $query): EmailResponse
     {
-        return $this->handle('cleanEmail', $query);
+        /** @var EmailResponse $response */
+        $response = $this->handle('cleanEmail', $query);
+
+        return $response;
     }
 }

--- a/src/Service/DadataGeneral.php
+++ b/src/Service/DadataGeneral.php
@@ -6,10 +6,9 @@ namespace Velhron\DadataBundle\Service;
 
 use Symfony\Contracts\HttpClient\Exception\ExceptionInterface;
 use Velhron\DadataBundle\Exception\DadataException;
+use Velhron\DadataBundle\Exception\InvalidConfigException;
 use Velhron\DadataBundle\Model\Request\AbstractRequest;
-use Velhron\DadataBundle\Model\Request\General\BalanceRequest;
 use Velhron\DadataBundle\Model\Request\General\StatRequest;
-use Velhron\DadataBundle\Model\Request\General\VersionRequest;
 use Velhron\DadataBundle\Model\Response\General\StatResponse;
 
 class DadataGeneral extends AbstractService
@@ -41,11 +40,11 @@ class DadataGeneral extends AbstractService
      *
      * @return float Текущий баланс счета
      *
-     * @throws DadataException
+     * @throws DadataException|InvalidConfigException
      */
     public function balance(): float
     {
-        $responseData = $this->query(new BalanceRequest());
+        $responseData = $this->query($this->requestFactory->create('balance'));
 
         return $responseData['balance'] ?? 0.0;
     }
@@ -59,11 +58,12 @@ class DadataGeneral extends AbstractService
      *
      * @return StatResponse Статистика
      *
-     * @throws DadataException
+     * @throws DadataException|InvalidConfigException
      */
     public function stat(string $date = null): StatResponse
     {
-        $request = new StatRequest();
+        /** @var StatRequest $request */
+        $request = $this->requestFactory->create('stat');
         $request->date = $date;
         $responseData = $this->query($request);
 
@@ -75,10 +75,10 @@ class DadataGeneral extends AbstractService
      *
      * @return array Информация по датам актуальности справочников
      *
-     * @throws DadataException
+     * @throws DadataException|InvalidConfigException
      */
     public function version(): array
     {
-        return $this->query(new VersionRequest());
+        return $this->query($this->requestFactory->create('version'));
     }
 }

--- a/src/Service/DadataGeolocate.php
+++ b/src/Service/DadataGeolocate.php
@@ -17,13 +17,6 @@ class DadataGeolocate extends AbstractService
     /**
      * Обработчик для API обратного геокодирования (по координатам).
      *
-     * @param string $method
-     * @param float  $latitude
-     * @param float  $longitude
-     * @param array  $options
-     *
-     * @return array
-     *
      * @throws DadataException|InvalidConfigException
      */
     private function handle(string $method, float $latitude, float $longitude, array $options = []): array

--- a/src/Service/DadataGeolocate.php
+++ b/src/Service/DadataGeolocate.php
@@ -6,6 +6,7 @@ namespace Velhron\DadataBundle\Service;
 
 use Symfony\Contracts\HttpClient\Exception\ExceptionInterface;
 use Velhron\DadataBundle\Exception\DadataException;
+use Velhron\DadataBundle\Exception\InvalidConfigException;
 use Velhron\DadataBundle\Model\Request\AbstractRequest;
 use Velhron\DadataBundle\Model\Request\Geolocate\GeolocateRequest;
 use Velhron\DadataBundle\Model\Response\Suggest\AddressResponse;
@@ -16,15 +17,20 @@ class DadataGeolocate extends AbstractService
     /**
      * Обработчик для API обратного геокодирования (по координатам).
      *
-     * @throws DadataException
+     * @param string $method
+     * @param float  $latitude
+     * @param float  $longitude
+     * @param array  $options
+     *
+     * @return array
+     *
+     * @throws DadataException|InvalidConfigException
      */
     private function handle(string $method, float $latitude, float $longitude, array $options = []): array
     {
-        $requestClass = $this->resolver->getMatchedRequest($method);
-        $responseClass = $this->resolver->getMatchedResponse($method);
-
         /* @var GeolocateRequest $request */
-        $request = new $requestClass();
+        $request = $this->requestFactory->create($method);
+
         $request->fillOptions(array_merge([
             'lat' => $latitude,
             'lon' => $longitude,
@@ -32,7 +38,7 @@ class DadataGeolocate extends AbstractService
 
         $responseData = $this->query($request);
         foreach ($responseData['suggestions'] ?? [] as $suggestion) {
-            $data[] = new $responseClass($suggestion);
+            $data[] = $this->responseFactory->create($method, $suggestion);
         }
 
         return $data ?? [];
@@ -70,7 +76,7 @@ class DadataGeolocate extends AbstractService
      *
      * @return AddressResponse[]
      *
-     * @throws DadataException
+     * @throws DadataException|InvalidConfigException
      */
     public function geolocateAddress(float $latitude, float $longitude, array $options = []): array
     {
@@ -86,7 +92,7 @@ class DadataGeolocate extends AbstractService
      *
      * @return PostalUnitResponse[]
      *
-     * @throws DadataException
+     * @throws DadataException|InvalidConfigException
      */
     public function geolocatePostalUnit(float $latitude, float $longitude, array $options = []): array
     {

--- a/src/Service/DadataIplocate.php
+++ b/src/Service/DadataIplocate.php
@@ -17,12 +17,6 @@ class DadataIplocate extends AbstractService
     /**
      * Обработчик для API по IP-адресу.
      *
-     * @param string $method
-     * @param string $ip
-     * @param array  $options
-     *
-     * @return AbstractResponse|null
-     *
      * @throws DadataException|InvalidConfigException
      */
     private function handle(string $method, string $ip, array $options = []): ?AbstractResponse

--- a/src/Service/DadataIplocate.php
+++ b/src/Service/DadataIplocate.php
@@ -6,8 +6,10 @@ namespace Velhron\DadataBundle\Service;
 
 use Symfony\Contracts\HttpClient\Exception\ExceptionInterface;
 use Velhron\DadataBundle\Exception\DadataException;
+use Velhron\DadataBundle\Exception\InvalidConfigException;
 use Velhron\DadataBundle\Model\Request\AbstractRequest;
-use Velhron\DadataBundle\Model\Request\Iplocate\IplocateRequest;
+use Velhron\DadataBundle\Model\Request\Iplocate\AddressRequest;
+use Velhron\DadataBundle\Model\Response\AbstractResponse;
 use Velhron\DadataBundle\Model\Response\Suggest\AddressResponse;
 
 class DadataIplocate extends AbstractService
@@ -15,22 +17,28 @@ class DadataIplocate extends AbstractService
     /**
      * Обработчик для API по IP-адресу.
      *
-     * @throws DadataException
+     * @param string $method
+     * @param string $ip
+     * @param array  $options
+     *
+     * @return AbstractResponse|null
+     *
+     * @throws DadataException|InvalidConfigException
      */
-    private function handle(string $method, string $ip, array $options = [])
+    private function handle(string $method, string $ip, array $options = []): ?AbstractResponse
     {
-        $requestClass = $this->resolver->getMatchedRequest($method);
-        $responseClass = $this->resolver->getMatchedResponse($method);
+        /* @var AddressRequest $request */
+        $request = $this->requestFactory->create($method);
 
-        /* @var IplocateRequest $request */
-        $request = new $requestClass();
         $request
             ->setQuery($ip)
             ->fillOptions($options);
 
         $responseData = $this->query($request);
 
-        return isset($responseData['location']) ? new $responseClass($responseData['location']) : null;
+        return isset($responseData['location'])
+            ? $this->responseFactory->create($method, $responseData['location'])
+            : null;
     }
 
     /**
@@ -66,10 +74,13 @@ class DadataIplocate extends AbstractService
      *
      * @return AddressResponse|null - ответ
      *
-     * @throws DadataException
+     * @throws DadataException|InvalidConfigException
      */
     public function iplocateAddress(string $ip, array $options = []): ?AddressResponse
     {
-        return $this->handle('iplocateAddress', $ip, $options);
+        /** @var AddressResponse|null $response */
+        $response = $this->handle('iplocateAddress', $ip, $options);
+
+        return $response;
     }
 }

--- a/src/Service/DadataSuggest.php
+++ b/src/Service/DadataSuggest.php
@@ -6,6 +6,7 @@ namespace Velhron\DadataBundle\Service;
 
 use Symfony\Contracts\HttpClient\Exception\ExceptionInterface;
 use Velhron\DadataBundle\Exception\DadataException;
+use Velhron\DadataBundle\Exception\InvalidConfigException;
 use Velhron\DadataBundle\Model\Request\AbstractRequest;
 use Velhron\DadataBundle\Model\Request\Suggest\SuggestRequest;
 use Velhron\DadataBundle\Model\Response\Find\AffiliatedPartyResponse;
@@ -31,25 +32,30 @@ class DadataSuggest extends AbstractService
     /**
      * Обработчик для API подсказок.
      *
-     * @throws DadataException
+     * @param string $method
+     * @param string $query
+     * @param array  $options
+     *
+     * @return array
+     *
+     * @throws DadataException|InvalidConfigException
      */
     private function handle(string $method, string $query, array $options = []): array
     {
-        $requestClass = $this->resolver->getMatchedRequest($method);
-        $responseClass = $this->resolver->getMatchedResponse($method);
-
         /* @var SuggestRequest $request */
-        $request = new $requestClass();
+        $request = $this->requestFactory->create($method);
         $request
             ->setQuery($query)
             ->fillOptions($options);
 
         $responseData = $this->query($request);
+
+        $data = [];
         foreach ($responseData['suggestions'] ?? [] as $suggestion) {
-            $data[] = new $responseClass($suggestion);
+            $data[] = $this->responseFactory->create($method, $suggestion);
         }
 
-        return $data ?? [];
+        return $data;
     }
 
     /**
@@ -85,7 +91,7 @@ class DadataSuggest extends AbstractService
      *
      * @return AddressResponse[] Массив подсказок
      *
-     * @throws DadataException
+     * @throws DadataException|InvalidConfigException
      */
     public function suggestAddress(string $query, array $options = []): array
     {
@@ -107,7 +113,7 @@ class DadataSuggest extends AbstractService
      *
      * @return PartyResponse[] Массив подсказок
      *
-     * @throws DadataException
+     * @throws DadataException|InvalidConfigException
      */
     public function suggestParty(string $query, array $options = []): array
     {
@@ -122,7 +128,7 @@ class DadataSuggest extends AbstractService
      *
      * @return BankResponse[] Массив подсказок
      *
-     * @throws DadataException
+     * @throws DadataException|InvalidConfigException
      */
     public function suggestBank(string $query, array $options = []): array
     {
@@ -141,7 +147,7 @@ class DadataSuggest extends AbstractService
      *
      * @return FioResponse[] Массив подсказок
      *
-     * @throws DadataException
+     * @throws DadataException|InvalidConfigException
      */
     public function suggestFio(string $query, array $options = []): array
     {
@@ -159,7 +165,7 @@ class DadataSuggest extends AbstractService
      *
      * @return EmailResponse[] Массив подсказок
      *
-     * @throws DadataException
+     * @throws DadataException|InvalidConfigException
      */
     public function suggestEmail(string $query, array $options = []): array
     {
@@ -176,7 +182,7 @@ class DadataSuggest extends AbstractService
      *
      * @return AddressResponse[] Массив подсказок
      *
-     * @throws DadataException
+     * @throws DadataException|InvalidConfigException
      */
     public function suggestFias(string $query, array $options = []): array
     {
@@ -191,7 +197,7 @@ class DadataSuggest extends AbstractService
      *
      * @return FmsUnitResponse[] Массив подсказок
      *
-     * @throws DadataException
+     * @throws DadataException|InvalidConfigException
      */
     public function suggestFmsUnit(string $query, array $options = []): array
     {
@@ -206,7 +212,7 @@ class DadataSuggest extends AbstractService
      *
      * @return PostalUnitResponse[] Массив подсказок
      *
-     * @throws DadataException
+     * @throws DadataException|InvalidConfigException
      */
     public function suggestPostalUnit(string $query, array $options = []): array
     {
@@ -223,7 +229,7 @@ class DadataSuggest extends AbstractService
      *
      * @return FnsUnitResponse[] Массив подсказок
      *
-     * @throws DadataException
+     * @throws DadataException|InvalidConfigException
      */
     public function suggestFnsUnit(string $query, array $options = []): array
     {
@@ -240,7 +246,7 @@ class DadataSuggest extends AbstractService
      *
      * @return RegionCourtResponse[] Массив подсказок
      *
-     * @throws DadataException
+     * @throws DadataException|InvalidConfigException
      */
     public function suggestRegionCourt(string $query, array $options = []): array
     {
@@ -257,7 +263,7 @@ class DadataSuggest extends AbstractService
      *
      * @return MetroResponse[] Массив подсказок
      *
-     * @throws DadataException
+     * @throws DadataException|InvalidConfigException
      */
     public function suggestMetro(string $query, array $options = []): array
     {
@@ -274,7 +280,7 @@ class DadataSuggest extends AbstractService
      *
      * @return CarBrandResponse[] Массив подсказок
      *
-     * @throws DadataException
+     * @throws DadataException|InvalidConfigException
      */
     public function suggestCarBrand(string $query, array $options = []): array
     {
@@ -291,7 +297,7 @@ class DadataSuggest extends AbstractService
      *
      * @return CountryResponse[] Массив подсказок
      *
-     * @throws DadataException
+     * @throws DadataException|InvalidConfigException
      */
     public function suggestCountry(string $query, array $options = []): array
     {
@@ -308,7 +314,7 @@ class DadataSuggest extends AbstractService
      *
      * @return CurrencyResponse[] Массив подсказок
      *
-     * @throws DadataException
+     * @throws DadataException|InvalidConfigException
      */
     public function suggestCurrency(string $query, array $options = []): array
     {
@@ -325,7 +331,7 @@ class DadataSuggest extends AbstractService
      *
      * @return Okved2Response[] Массив подсказок
      *
-     * @throws DadataException
+     * @throws DadataException|InvalidConfigException
      */
     public function suggestOkved2(string $query, array $options = []): array
     {
@@ -342,7 +348,7 @@ class DadataSuggest extends AbstractService
      *
      * @return Okpd2Response[] Массив подсказок
      *
-     * @throws DadataException
+     * @throws DadataException|InvalidConfigException
      */
     public function suggestOkpd2(string $query, array $options = []): array
     {
@@ -359,7 +365,7 @@ class DadataSuggest extends AbstractService
      *
      * @return AddressResponse[] Массив подсказок
      *
-     * @throws DadataException
+     * @throws DadataException|InvalidConfigException
      */
     public function findAddress(string $query, array $options = []): array
     {
@@ -374,7 +380,7 @@ class DadataSuggest extends AbstractService
      *
      * @return PostalUnitResponse[] Массив подсказок
      *
-     * @throws DadataException
+     * @throws DadataException|InvalidConfigException
      */
     public function findPostalUnit(string $query, array $options = []): array
     {
@@ -389,7 +395,7 @@ class DadataSuggest extends AbstractService
      *
      * @return DeliveryResponse[] Массив подсказок
      *
-     * @throws DadataException
+     * @throws DadataException|InvalidConfigException
      */
     public function findDelivery(string $query, array $options = []): array
     {
@@ -408,7 +414,7 @@ class DadataSuggest extends AbstractService
      *
      * @return PartyResponse[] Массив подсказок
      *
-     * @throws DadataException
+     * @throws DadataException|InvalidConfigException
      */
     public function findParty(string $query, array $options = []): array
     {
@@ -433,7 +439,7 @@ class DadataSuggest extends AbstractService
      *
      * @return BankResponse[] Массив подсказок
      *
-     * @throws DadataException
+     * @throws DadataException|InvalidConfigException
      */
     public function findBank(string $query, array $options = []): array
     {
@@ -448,7 +454,7 @@ class DadataSuggest extends AbstractService
      *
      * @return AddressResponse[] Массив подсказок
      *
-     * @throws DadataException
+     * @throws DadataException|InvalidConfigException
      */
     public function findFias(string $query, array $options = []): array
     {
@@ -465,7 +471,7 @@ class DadataSuggest extends AbstractService
      *
      * @return AffiliatedPartyResponse[] Массив подсказок
      *
-     * @throws DadataException
+     * @throws DadataException|InvalidConfigException
      */
     public function findAffiliatedParty(string $query, array $options = []): array
     {

--- a/src/Service/DadataSuggest.php
+++ b/src/Service/DadataSuggest.php
@@ -32,12 +32,6 @@ class DadataSuggest extends AbstractService
     /**
      * Обработчик для API подсказок.
      *
-     * @param string $method
-     * @param string $query
-     * @param array  $options
-     *
-     * @return array
-     *
      * @throws DadataException|InvalidConfigException
      */
     private function handle(string $method, string $query, array $options = []): array

--- a/tests/DependencyInjection/VelhronDadataExtensionTest.php
+++ b/tests/DependencyInjection/VelhronDadataExtensionTest.php
@@ -14,7 +14,7 @@ class VelhronDadataExtensionTest extends TestCase
 {
     public function testRegister(): void
     {
-        $config = Yaml::parse(file_get_contents(__DIR__ . '/config.yaml'));
+        $config = Yaml::parse(file_get_contents(__DIR__.'/config.yaml'));
 
         $containerBuilder = new ContainerBuilder();
         $containerBuilder->setParameter('kernel.debug', true);

--- a/tests/DependencyInjection/VelhronDadataExtensionTest.php
+++ b/tests/DependencyInjection/VelhronDadataExtensionTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Velhron\DadataBundle\Tests\DependencyInjection;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Yaml\Yaml;
@@ -13,7 +14,7 @@ class VelhronDadataExtensionTest extends TestCase
 {
     public function testRegister(): void
     {
-        $config = Yaml::parse(file_get_contents(__DIR__.'/config.yaml'));
+        $config = Yaml::parse(file_get_contents(__DIR__ . '/config.yaml'));
 
         $containerBuilder = new ContainerBuilder();
         $containerBuilder->setParameter('kernel.debug', true);
@@ -23,5 +24,35 @@ class VelhronDadataExtensionTest extends TestCase
 
         $this->assertSame('token', $containerBuilder->getParameter('velhron_dadata.token'));
         $this->assertSame('secret', $containerBuilder->getParameter('velhron_dadata.secret'));
+        $this->assertSame('https://example.com/general', $containerBuilder->getParameter('velhron_dadata.base_general_url'));
+        $this->assertSame('https://example.com/cleaner', $containerBuilder->getParameter('velhron_dadata.base_cleaner_url'));
+        $this->assertSame('https://example.com/suggetions', $containerBuilder->getParameter('velhron_dadata.base_suggestions_url'));
+    }
+
+    public function testRegisterWithDefaults(): void
+    {
+        /** @var ContainerBuilder|MockObject $containerBuilder */
+        $containerBuilder = $this->getMockBuilder(ContainerBuilder::class)->disableOriginalConstructor()->getMock();
+
+        $containerBuilder
+            ->expects($this->exactly(5))
+            ->method('setParameter')
+            ->withConsecutive(
+                ['velhron_dadata.token', 'token12345'],
+                ['velhron_dadata.secret', 'secret12345'],
+                ['velhron_dadata.base_general_url', 'https://dadata.ru/api/v2'],
+                ['velhron_dadata.base_cleaner_url', 'https://cleaner.dadata.ru/api/v1/clean'],
+                ['velhron_dadata.base_suggestions_url', 'https://suggestions.dadata.ru/suggestions/api/4_1/rs']
+            );
+
+        $config = [
+            'velhron_dadata' => [
+                'token' => 'token12345',
+                'secret' => 'secret12345',
+            ],
+        ];
+
+        $extension = new VelhronDadataExtension();
+        $extension->load($config, $containerBuilder);
     }
 }

--- a/tests/DependencyInjection/config.yaml
+++ b/tests/DependencyInjection/config.yaml
@@ -1,3 +1,6 @@
 velhron_dadata:
   token: 'token'
   secret: 'secret'
+  base_general_url: 'https://example.com/general'
+  base_cleaner_url: 'https://example.com/cleaner'
+  base_suggestions_url: 'https://example.com/suggetions'

--- a/tests/Service/DadataCleanTest.php
+++ b/tests/Service/DadataCleanTest.php
@@ -17,7 +17,7 @@ class DadataCleanTest extends DadataServiceTest
 
     public function testCleanAddress(): void
     {
-        $service = $this->createService(__DIR__ . '/../mocks/Clean/address.json');
+        $service = $this->createService(__DIR__.'/../mocks/Clean/address.json');
         $result = $service->cleanAddress('мск сухонска 11/-89');
 
         $this->assertEquals(0, $result->qc);
@@ -27,7 +27,7 @@ class DadataCleanTest extends DadataServiceTest
 
     public function testCleanPhone(): void
     {
-        $service = $this->createService(__DIR__ . '/../mocks/Clean/phone.json');
+        $service = $this->createService(__DIR__.'/../mocks/Clean/phone.json');
         $result = $service->cleanPhone('раб 846)231.60.14 *139');
 
         $this->assertEquals('+7 846 231-60-14 доб. 139', $result->phone);
@@ -36,7 +36,7 @@ class DadataCleanTest extends DadataServiceTest
 
     public function testCleanPassport(): void
     {
-        $service = $this->createService(__DIR__ . '/../mocks/Clean/passport.json');
+        $service = $this->createService(__DIR__.'/../mocks/Clean/passport.json');
         $result = $service->cleanPassport('4509 235857');
 
         $this->assertEquals('45 09', $result->series);
@@ -45,7 +45,7 @@ class DadataCleanTest extends DadataServiceTest
 
     public function testCleanBirthdate(): void
     {
-        $service = $this->createService(__DIR__ . '/../mocks/Clean/birthdate.json');
+        $service = $this->createService(__DIR__.'/../mocks/Clean/birthdate.json');
         $result = $service->cleanBirthdate('24/3/12');
 
         $this->assertEquals('24.03.2012', $result->birthdate);
@@ -53,7 +53,7 @@ class DadataCleanTest extends DadataServiceTest
 
     public function testCleanVehicle(): void
     {
-        $service = $this->createService(__DIR__ . '/../mocks/Clean/vehicle.json');
+        $service = $this->createService(__DIR__.'/../mocks/Clean/vehicle.json');
         $result = $service->cleanVehicle('бмв');
 
         $this->assertEquals('BMW', $result->brand);
@@ -61,7 +61,7 @@ class DadataCleanTest extends DadataServiceTest
 
     public function testCleanName(): void
     {
-        $service = $this->createService(__DIR__ . '/../mocks/Clean/name.json');
+        $service = $this->createService(__DIR__.'/../mocks/Clean/name.json');
         $result = $service->cleanName('Срегей владимерович иванов');
 
         $this->assertEquals('Иванов', $result->surname);
@@ -71,7 +71,7 @@ class DadataCleanTest extends DadataServiceTest
 
     public function testCleanEmail(): void
     {
-        $service = $this->createService(__DIR__ . '/../mocks/Clean/email.json');
+        $service = $this->createService(__DIR__.'/../mocks/Clean/email.json');
         $result = $service->cleanEmail('serega@yandex/ru');
 
         $this->assertEquals('serega@yandex.ru', $result->email);
@@ -84,53 +84,48 @@ class DadataCleanTest extends DadataServiceTest
                 'cleanAddress',
                 '/address',
                 'мск сухонска 11/-89',
-                __DIR__ . '/../mocks/Clean/address.json',
+                __DIR__.'/../mocks/Clean/address.json',
             ],
             [
                 'cleanPhone',
                 '/phone',
                 'раб 846)231.60.14 *139',
-                __DIR__ . '/../mocks/Clean/phone.json',
+                __DIR__.'/../mocks/Clean/phone.json',
             ],
             [
                 'cleanPassport',
                 '/passport',
                 '4509 235857',
-                __DIR__ . '/../mocks/Clean/passport.json',
+                __DIR__.'/../mocks/Clean/passport.json',
             ],
             [
                 'cleanBirthdate',
                 '/birthdate',
                 '24/3/12',
-                __DIR__ . '/../mocks/Clean/birthdate.json',
+                __DIR__.'/../mocks/Clean/birthdate.json',
             ],
             [
                 'cleanVehicle',
                 '/vehicle',
                 'бмв',
-                __DIR__ . '/../mocks/Clean/vehicle.json',
+                __DIR__.'/../mocks/Clean/vehicle.json',
             ],
             [
                 'cleanName',
                 '/name',
                 'Срегей владимерович иванов',
-                __DIR__ . '/../mocks/Clean/name.json',
+                __DIR__.'/../mocks/Clean/name.json',
             ],
             [
                 'cleanEmail',
                 '/email',
                 'serega@yandex/ru',
-                __DIR__ . '/../mocks/Clean/email.json',
+                __DIR__.'/../mocks/Clean/email.json',
             ],
         ];
     }
 
     /**
-     * @param string $methodName
-     * @param string $methodUrl
-     * @param string $query
-     * @param string $filePath
-     *
      * @dataProvider dataProvider
      */
     public function testRequestParams(
@@ -139,12 +134,12 @@ class DadataCleanTest extends DadataServiceTest
         string $query,
         string $filePath
     ): void {
-        $expectedUrl = 'https://example.com/cleaner' . $methodUrl;
+        $expectedUrl = 'https://example.com/cleaner'.$methodUrl;
 
         $expectedOptions = [
             'headers' => [
                 'Content-Type' => 'application/json',
-                'Authorization' => "Token token",
+                'Authorization' => 'Token token',
                 'X-Secret' => 'secret',
             ],
             'body' => json_encode([$query]),

--- a/tests/Service/DadataGeneralTest.php
+++ b/tests/Service/DadataGeneralTest.php
@@ -17,7 +17,7 @@ class DadataGeneralTest extends DadataServiceTest
 
     public function testBalance(): void
     {
-        $service = $this->createService(__DIR__ . '/../mocks/General/balance.json');
+        $service = $this->createService(__DIR__.'/../mocks/General/balance.json');
         $result = $service->balance();
 
         $this->assertEquals(7.0, $result);
@@ -25,7 +25,7 @@ class DadataGeneralTest extends DadataServiceTest
 
     public function testStat(): void
     {
-        $service = $this->createService(__DIR__ . '/../mocks/General/stat.json');
+        $service = $this->createService(__DIR__.'/../mocks/General/stat.json');
         $result = $service->stat();
 
         $this->assertEquals('2020-07-09', $result->date);
@@ -39,30 +39,26 @@ class DadataGeneralTest extends DadataServiceTest
             [
                 'balance',
                 '/profile/balance',
-                __DIR__ . '/../mocks/General/balance.json',
+                __DIR__.'/../mocks/General/balance.json',
             ],
             [
                 'stat',
                 '/stat/daily',
-                __DIR__ . '/../mocks/General/stat.json',
+                __DIR__.'/../mocks/General/stat.json',
             ],
         ];
     }
 
     /**
-     * @param string $methodName
-     * @param string $methodUrl
-     * @param string $filePath
-     *
      * @dataProvider dataProvider
      */
     public function testRequestParams(string $methodName, string $methodUrl, string $filePath): void
     {
-        $expectedUrl = 'https://example.com/general' . $methodUrl;
+        $expectedUrl = 'https://example.com/general'.$methodUrl;
 
         $expectedOptions = [
             'headers' => [
-                'Authorization' => "Token token",
+                'Authorization' => 'Token token',
                 'X-Secret' => 'secret',
             ],
             'query' => [],

--- a/tests/Service/DadataGeneralTest.php
+++ b/tests/Service/DadataGeneralTest.php
@@ -4,18 +4,20 @@ declare(strict_types=1);
 
 namespace Velhron\DadataBundle\Tests\Service;
 
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
 use Velhron\DadataBundle\Service\DadataGeneral;
 
 class DadataGeneralTest extends DadataServiceTest
 {
     protected function createService(string $mockFilepath): DadataGeneral
     {
-        return new DadataGeneral('', '', $this->resolver, $this->getMockHttpClient($mockFilepath));
+        return new DadataGeneral('', '', $this->getMockHttpClient($mockFilepath), $this->requestFactory, $this->responseFactory);
     }
 
     public function testBalance(): void
     {
-        $service = $this->createService(__DIR__.'/../mocks/General/balance.json');
+        $service = $this->createService(__DIR__ . '/../mocks/General/balance.json');
         $result = $service->balance();
 
         $this->assertEquals(7.0, $result);
@@ -23,11 +25,66 @@ class DadataGeneralTest extends DadataServiceTest
 
     public function testStat(): void
     {
-        $service = $this->createService(__DIR__.'/../mocks/General/stat.json');
+        $service = $this->createService(__DIR__ . '/../mocks/General/stat.json');
         $result = $service->stat();
 
         $this->assertEquals('2020-07-09', $result->date);
         $this->assertEquals(36, $result->suggestions);
         $this->assertEquals(7, $result->clean);
+    }
+
+    public function dataProvider(): array
+    {
+        return [
+            [
+                'balance',
+                '/profile/balance',
+                __DIR__ . '/../mocks/General/balance.json',
+            ],
+            [
+                'stat',
+                '/stat/daily',
+                __DIR__ . '/../mocks/General/stat.json',
+            ],
+        ];
+    }
+
+    /**
+     * @param string $methodName
+     * @param string $methodUrl
+     * @param string $filePath
+     *
+     * @dataProvider dataProvider
+     */
+    public function testRequestParams(string $methodName, string $methodUrl, string $filePath): void
+    {
+        $expectedUrl = 'https://example.com/general' . $methodUrl;
+
+        $expectedOptions = [
+            'headers' => [
+                'Authorization' => "Token token",
+                'X-Secret' => 'secret',
+            ],
+            'query' => [],
+        ];
+
+        $response = $this->createMock(ResponseInterface::class);
+
+        $response
+            ->expects($this->once())
+            ->method('getContent')
+            ->willReturn(file_get_contents($filePath));
+
+        $httpClient = $this->createMock(HttpClientInterface::class);
+
+        $httpClient
+            ->expects($this->once())
+            ->method('request')
+            ->with('GET', $expectedUrl, $expectedOptions)
+            ->willReturn($response);
+
+        $service = new DadataGeneral('token', 'secret', $httpClient, $this->requestFactory, $this->responseFactory);
+
+        $service->$methodName();
     }
 }

--- a/tests/Service/DadataGeolocateTest.php
+++ b/tests/Service/DadataGeolocateTest.php
@@ -4,18 +4,20 @@ declare(strict_types=1);
 
 namespace Velhron\DadataBundle\Tests\Service;
 
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
 use Velhron\DadataBundle\Service\DadataGeolocate;
 
 class DadataGeolocateTest extends DadataServiceTest
 {
     protected function createService(string $mockFilepath): DadataGeolocate
     {
-        return new DadataGeolocate('', '', $this->resolver, $this->getMockHttpClient($mockFilepath));
+        return new DadataGeolocate('', '', $this->getMockHttpClient($mockFilepath), $this->requestFactory, $this->responseFactory);
     }
 
     public function testGeolocateAddress(): void
     {
-        $service = $this->createService(__DIR__.'/../mocks/Geolocate/address.json');
+        $service = $this->createService(__DIR__ . '/../mocks/Geolocate/address.json');
         $result = $service->geolocateAddress(55.878, 37.653);
 
         $this->assertEquals('г Москва, ул Сухонская, д 11', $result[0]->value);
@@ -24,10 +26,66 @@ class DadataGeolocateTest extends DadataServiceTest
 
     public function testGeolocatePostalUnit(): void
     {
-        $service = $this->createService(__DIR__.'/../mocks/Geolocate/postalUnit.json');
+        $service = $this->createService(__DIR__ . '/../mocks/Geolocate/postalUnit.json');
         $result = $service->geolocatePostalUnit(55.878, 37.653, ['radius_meters' => 1000]);
 
         $this->assertEquals('127642', $result[0]->postalCode);
         $this->assertEquals('г Москва, проезд Дежнёва, д 2А', $result[0]->addressStr);
+    }
+
+    public function dataProvider(): array
+    {
+        return [
+            [
+                'geolocateAddress',
+                '/geolocate/address',
+                __DIR__ . '/../mocks/Geolocate/address.json',
+            ],
+            [
+                'geolocatePostalUnit',
+                '/geolocate/postal_unit',
+                __DIR__ . '/../mocks/Geolocate/postalUnit.json',
+            ],
+        ];
+    }
+
+    /**
+     * @param string $methodName
+     * @param string $methodUrl
+     * @param string $filePath
+     *
+     * @dataProvider dataProvider
+     */
+    public function testRequestParams(string $methodName, string $methodUrl, string $filePath): void
+    {
+        $expectedUrl = 'https://example.com/suggetions' . $methodUrl;
+
+        $expectedOptions = [
+            'headers' => [
+                'Content-Type' => 'application/json',
+                'Accept' => 'application/json',
+                'Authorization' => "Token token",
+            ],
+            'body' => '{"lat":55.878,"lon":37.653}',
+        ];
+
+        $response = $this->createMock(ResponseInterface::class);
+
+        $response
+            ->expects($this->once())
+            ->method('getContent')
+            ->willReturn(file_get_contents($filePath));
+
+        $httpClient = $this->createMock(HttpClientInterface::class);
+
+        $httpClient
+            ->expects($this->once())
+            ->method('request')
+            ->with('POST', $expectedUrl, $expectedOptions)
+            ->willReturn($response);
+
+        $service = new DadataGeolocate('token', 'secret', $httpClient, $this->requestFactory, $this->responseFactory);
+
+        $service->$methodName(55.878, 37.653);
     }
 }

--- a/tests/Service/DadataGeolocateTest.php
+++ b/tests/Service/DadataGeolocateTest.php
@@ -17,7 +17,7 @@ class DadataGeolocateTest extends DadataServiceTest
 
     public function testGeolocateAddress(): void
     {
-        $service = $this->createService(__DIR__ . '/../mocks/Geolocate/address.json');
+        $service = $this->createService(__DIR__.'/../mocks/Geolocate/address.json');
         $result = $service->geolocateAddress(55.878, 37.653);
 
         $this->assertEquals('г Москва, ул Сухонская, д 11', $result[0]->value);
@@ -26,7 +26,7 @@ class DadataGeolocateTest extends DadataServiceTest
 
     public function testGeolocatePostalUnit(): void
     {
-        $service = $this->createService(__DIR__ . '/../mocks/Geolocate/postalUnit.json');
+        $service = $this->createService(__DIR__.'/../mocks/Geolocate/postalUnit.json');
         $result = $service->geolocatePostalUnit(55.878, 37.653, ['radius_meters' => 1000]);
 
         $this->assertEquals('127642', $result[0]->postalCode);
@@ -39,32 +39,28 @@ class DadataGeolocateTest extends DadataServiceTest
             [
                 'geolocateAddress',
                 '/geolocate/address',
-                __DIR__ . '/../mocks/Geolocate/address.json',
+                __DIR__.'/../mocks/Geolocate/address.json',
             ],
             [
                 'geolocatePostalUnit',
                 '/geolocate/postal_unit',
-                __DIR__ . '/../mocks/Geolocate/postalUnit.json',
+                __DIR__.'/../mocks/Geolocate/postalUnit.json',
             ],
         ];
     }
 
     /**
-     * @param string $methodName
-     * @param string $methodUrl
-     * @param string $filePath
-     *
      * @dataProvider dataProvider
      */
     public function testRequestParams(string $methodName, string $methodUrl, string $filePath): void
     {
-        $expectedUrl = 'https://example.com/suggetions' . $methodUrl;
+        $expectedUrl = 'https://example.com/suggetions'.$methodUrl;
 
         $expectedOptions = [
             'headers' => [
                 'Content-Type' => 'application/json',
                 'Accept' => 'application/json',
-                'Authorization' => "Token token",
+                'Authorization' => 'Token token',
             ],
             'body' => '{"lat":55.878,"lon":37.653}',
         ];

--- a/tests/Service/DadataIplocateTest.php
+++ b/tests/Service/DadataIplocateTest.php
@@ -17,7 +17,7 @@ class DadataIplocateTest extends DadataServiceTest
 
     public function testIplocateAddress(): void
     {
-        $service = $this->createService(__DIR__ . '/../mocks/Iplocate/address.json');
+        $service = $this->createService(__DIR__.'/../mocks/Iplocate/address.json');
         $result = $service->iplocateAddress('46.226.227.20');
 
         $this->assertEquals('г Белгород', $result->value);
@@ -31,27 +31,23 @@ class DadataIplocateTest extends DadataServiceTest
             [
                 'iplocateAddress',
                 '/iplocate/address',
-                __DIR__ . '/../mocks/Iplocate/address.json',
+                __DIR__.'/../mocks/Iplocate/address.json',
             ],
         ];
     }
 
     /**
-     * @param string $methodName
-     * @param string $methodUrl
-     * @param string $filePath
-     *
      * @dataProvider dataProvider
      */
     public function testRequestParams(string $methodName, string $methodUrl, string $filePath): void
     {
-        $expectedUrl = 'https://example.com/suggetions' . $methodUrl;
+        $expectedUrl = 'https://example.com/suggetions'.$methodUrl;
 
         $expectedOptions = [
             'headers' => [
                 'Content-Type' => 'application/json',
                 'Accept' => 'application/json',
-                'Authorization' => "Token token",
+                'Authorization' => 'Token token',
             ],
             'query' => ['query' => '46.226.227.20'],
         ];

--- a/tests/Service/DadataIplocateTest.php
+++ b/tests/Service/DadataIplocateTest.php
@@ -4,22 +4,75 @@ declare(strict_types=1);
 
 namespace Velhron\DadataBundle\Tests\Service;
 
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
 use Velhron\DadataBundle\Service\DadataIplocate;
 
 class DadataIplocateTest extends DadataServiceTest
 {
     protected function createService(string $mockFilepath): DadataIplocate
     {
-        return new DadataIplocate('', '', $this->resolver, $this->getMockHttpClient($mockFilepath));
+        return new DadataIplocate('', '', $this->getMockHttpClient($mockFilepath), $this->requestFactory, $this->responseFactory);
     }
 
     public function testIplocateAddress(): void
     {
-        $service = $this->createService(__DIR__.'/../mocks/Iplocate/address.json');
+        $service = $this->createService(__DIR__ . '/../mocks/Iplocate/address.json');
         $result = $service->iplocateAddress('46.226.227.20');
 
         $this->assertEquals('г Белгород', $result->value);
         $this->assertEquals('639efe9d-3fc8-4438-8e70-ec4f2321f2a7', $result->regionFiasId);
         $this->assertEquals('31000001000000000000000', $result->fiasCode);
+    }
+
+    public function dataProvider(): array
+    {
+        return [
+            [
+                'iplocateAddress',
+                '/iplocate/address',
+                __DIR__ . '/../mocks/Iplocate/address.json',
+            ],
+        ];
+    }
+
+    /**
+     * @param string $methodName
+     * @param string $methodUrl
+     * @param string $filePath
+     *
+     * @dataProvider dataProvider
+     */
+    public function testRequestParams(string $methodName, string $methodUrl, string $filePath): void
+    {
+        $expectedUrl = 'https://example.com/suggetions' . $methodUrl;
+
+        $expectedOptions = [
+            'headers' => [
+                'Content-Type' => 'application/json',
+                'Accept' => 'application/json',
+                'Authorization' => "Token token",
+            ],
+            'query' => ['query' => '46.226.227.20'],
+        ];
+
+        $response = $this->createMock(ResponseInterface::class);
+
+        $response
+            ->expects($this->once())
+            ->method('getContent')
+            ->willReturn(file_get_contents($filePath));
+
+        $httpClient = $this->createMock(HttpClientInterface::class);
+
+        $httpClient
+            ->expects($this->once())
+            ->method('request')
+            ->with('GET', $expectedUrl, $expectedOptions)
+            ->willReturn($response);
+
+        $service = new DadataIplocate('token', 'secret', $httpClient, $this->requestFactory, $this->responseFactory);
+
+        $service->$methodName('46.226.227.20');
     }
 }

--- a/tests/Service/DadataServiceTest.php
+++ b/tests/Service/DadataServiceTest.php
@@ -7,15 +7,21 @@ namespace Velhron\DadataBundle\Tests\Service;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
-use Velhron\DadataBundle\Resolver;
+use Velhron\DadataBundle\RequestFactory;
+use Velhron\DadataBundle\ResponseFactory;
 use Velhron\DadataBundle\Tests\TestingKernel;
 
 abstract class DadataServiceTest extends TestCase
 {
     /**
-     * @var Resolver
+     * @var RequestFactory
      */
-    protected $resolver;
+    protected $requestFactory;
+
+    /**
+     * @var ResponseFactory
+     */
+    protected $responseFactory;
 
     abstract protected function createService(string $mockFilepath);
 
@@ -27,7 +33,8 @@ abstract class DadataServiceTest extends TestCase
         $kernel = new TestingKernel('test', false);
         $kernel->boot();
         $container = $kernel->getContainer();
-        $this->resolver = $container->get(Resolver::class);
+        $this->requestFactory = $container->get(RequestFactory::class);
+        $this->responseFactory = $container->get(ResponseFactory::class);
     }
 
     protected function getMockHttpClient(string $filepath): MockHttpClient

--- a/tests/Service/DadataSuggestTest.php
+++ b/tests/Service/DadataSuggestTest.php
@@ -6,7 +6,6 @@ namespace Velhron\DadataBundle\Tests\Service;
 
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
-use Velhron\DadataBundle\Exception\DadataException;
 use Velhron\DadataBundle\Service\DadataSuggest;
 
 class DadataSuggestTest extends DadataServiceTest
@@ -18,7 +17,7 @@ class DadataSuggestTest extends DadataServiceTest
 
     public function testSuggestAddress(): void
     {
-        $service = $this->createService(__DIR__ . '/../mocks/Suggest/address.json');
+        $service = $this->createService(__DIR__.'/../mocks/Suggest/address.json');
         $result = $service->suggestAddress('москва хабар', ['count' => 10]);
 
         $this->assertCount(10, $result);
@@ -28,7 +27,7 @@ class DadataSuggestTest extends DadataServiceTest
 
     public function testSuggestParty(): void
     {
-        $service = $this->createService(__DIR__ . '/../mocks/Suggest/party.json');
+        $service = $this->createService(__DIR__.'/../mocks/Suggest/party.json');
         $result = $service->suggestParty('сбербанк', ['count' => 2]);
 
         $this->assertCount(2, $result);
@@ -46,7 +45,7 @@ class DadataSuggestTest extends DadataServiceTest
 
     public function testSuggestBank(): void
     {
-        $service = $this->createService(__DIR__ . '/../mocks/Suggest/bank.json');
+        $service = $this->createService(__DIR__.'/../mocks/Suggest/bank.json');
         $result = $service->suggestBank('сбербанк', ['count' => 2]);
 
         $this->assertCount(2, $result);
@@ -57,7 +56,7 @@ class DadataSuggestTest extends DadataServiceTest
 
     public function testSuggestFio(): void
     {
-        $service = $this->createService(__DIR__ . '/../mocks/Suggest/fio.json');
+        $service = $this->createService(__DIR__.'/../mocks/Suggest/fio.json');
         $result = $service->suggestFio('Викт');
 
         $this->assertEquals('Виктор', $result[0]->value);
@@ -66,7 +65,7 @@ class DadataSuggestTest extends DadataServiceTest
 
     public function testSuggestEmail(): void
     {
-        $service = $this->createService(__DIR__ . '/../mocks/Suggest/email.json');
+        $service = $this->createService(__DIR__.'/../mocks/Suggest/email.json');
         $result = $service->suggestEmail('anton@');
 
         $this->assertEquals('anton@mail.ru', $result[0]->value);
@@ -76,7 +75,7 @@ class DadataSuggestTest extends DadataServiceTest
 
     public function testSuggestFias(): void
     {
-        $service = $this->createService(__DIR__ . '/../mocks/Suggest/fias.json');
+        $service = $this->createService(__DIR__.'/../mocks/Suggest/fias.json');
         $result = $service->suggestFias('москва хабар', ['count' => 2]);
 
         $this->assertCount(2, $result);
@@ -86,7 +85,7 @@ class DadataSuggestTest extends DadataServiceTest
 
     public function testSuggestFmsUnit(): void
     {
-        $service = $this->createService(__DIR__ . '/../mocks/Suggest/fmsUnit.json');
+        $service = $this->createService(__DIR__.'/../mocks/Suggest/fmsUnit.json');
         $result = $service->suggestFmsUnit('772 053');
 
         $this->assertEquals('ОВД ЗЮЗИНО Г. МОСКВЫ', $result[0]->value);
@@ -96,7 +95,7 @@ class DadataSuggestTest extends DadataServiceTest
 
     public function testSuggestPostalUnit(): void
     {
-        $service = $this->createService(__DIR__ . '/../mocks/Suggest/postalUnit.json');
+        $service = $this->createService(__DIR__.'/../mocks/Suggest/postalUnit.json');
         $result = $service->suggestPostalUnit('дежнева 2а');
 
         $this->assertEquals('127642', $result[0]->value);
@@ -106,7 +105,7 @@ class DadataSuggestTest extends DadataServiceTest
 
     public function testSuggestFnsUnit(): void
     {
-        $service = $this->createService(__DIR__ . '/../mocks/Suggest/fnsUnit.json');
+        $service = $this->createService(__DIR__.'/../mocks/Suggest/fnsUnit.json');
         $result = $service->suggestFnsUnit('нижнего');
 
         $this->assertEquals('Инспекция ФНС России по Автозаводскому району г.Нижнего Новгорода', $result[0]->value);
@@ -116,7 +115,7 @@ class DadataSuggestTest extends DadataServiceTest
 
     public function testSuggestRegionCourt(): void
     {
-        $service = $this->createService(__DIR__ . '/../mocks/Suggest/regionCourt.json');
+        $service = $this->createService(__DIR__.'/../mocks/Suggest/regionCourt.json');
         $result = $service->suggestRegionCourt('нижний');
 
         $this->assertEquals('52MS0001', $result[0]->code);
@@ -125,7 +124,7 @@ class DadataSuggestTest extends DadataServiceTest
 
     public function testSuggestMetro(): void
     {
-        $service = $this->createService(__DIR__ . '/../mocks/Suggest/metro.json');
+        $service = $this->createService(__DIR__.'/../mocks/Suggest/metro.json');
         $result = $service->suggestMetro('алек');
 
         $this->assertEquals('Александровский сад', $result[0]->value);
@@ -136,7 +135,7 @@ class DadataSuggestTest extends DadataServiceTest
 
     public function testSuggestCarBrand(): void
     {
-        $service = $this->createService(__DIR__ . '/../mocks/Suggest/carBrand.json');
+        $service = $this->createService(__DIR__.'/../mocks/Suggest/carBrand.json');
         $result = $service->suggestCarBrand('форд');
 
         $this->assertEquals('Ford', $result[0]->value);
@@ -145,7 +144,7 @@ class DadataSuggestTest extends DadataServiceTest
 
     public function testSuggestCountry(): void
     {
-        $service = $this->createService(__DIR__ . '/../mocks/Suggest/country.json');
+        $service = $this->createService(__DIR__.'/../mocks/Suggest/country.json');
         $result = $service->suggestCountry('та');
 
         $this->assertEquals('Таджикистан', $result[0]->value);
@@ -154,7 +153,7 @@ class DadataSuggestTest extends DadataServiceTest
 
     public function testSuggestCurrency(): void
     {
-        $service = $this->createService(__DIR__ . '/../mocks/Suggest/currency.json');
+        $service = $this->createService(__DIR__.'/../mocks/Suggest/currency.json');
         $result = $service->suggestCurrency('руб');
 
         $this->assertEquals('Белорусский рубль', $result[0]->value);
@@ -165,7 +164,7 @@ class DadataSuggestTest extends DadataServiceTest
 
     public function testSuggestOkved2(): void
     {
-        $service = $this->createService(__DIR__ . '/../mocks/Suggest/okved2.json');
+        $service = $this->createService(__DIR__.'/../mocks/Suggest/okved2.json');
         $result = $service->suggestOkved2('запуск');
 
         $this->assertEquals('H.51.22.3', $result[0]->idx);
@@ -174,7 +173,7 @@ class DadataSuggestTest extends DadataServiceTest
 
     public function testSuggestOkpd2(): void
     {
-        $service = $this->createService(__DIR__ . '/../mocks/Suggest/okpd2.json');
+        $service = $this->createService(__DIR__.'/../mocks/Suggest/okpd2.json');
         $result = $service->suggestOkpd2('калоши');
 
         $this->assertEquals('Услуги по обрезиневанию валенок (рыбацкие калоши)', $result[0]->value);
@@ -183,7 +182,7 @@ class DadataSuggestTest extends DadataServiceTest
 
     public function testFindAddress(): void
     {
-        $service = $this->createService(__DIR__ . '/../mocks/Find/address.json');
+        $service = $this->createService(__DIR__.'/../mocks/Find/address.json');
         $result = $service->findAddress('77000000000268400');
 
         $this->assertEquals('129323, г Москва, ул Снежная', $result[0]->unrestrictedValue);
@@ -192,7 +191,7 @@ class DadataSuggestTest extends DadataServiceTest
 
     public function testFindPostalUnit(): void
     {
-        $service = $this->createService(__DIR__ . '/../mocks/Find/postalUnit.json');
+        $service = $this->createService(__DIR__.'/../mocks/Find/postalUnit.json');
         $result = $service->findPostalUnit('127642');
 
         $this->assertEquals('127642', $result[0]->postalCode);
@@ -201,7 +200,7 @@ class DadataSuggestTest extends DadataServiceTest
 
     public function testFindDelivery(): void
     {
-        $service = $this->createService(__DIR__ . '/../mocks/Find/delivery.json');
+        $service = $this->createService(__DIR__.'/../mocks/Find/delivery.json');
         $result = $service->findDelivery('3100400100000');
 
         $this->assertEquals('3100400100000', $result[0]->kladrId);
@@ -211,7 +210,7 @@ class DadataSuggestTest extends DadataServiceTest
 
     public function testFindParty(): void
     {
-        $service = $this->createService(__DIR__ . '/../mocks/Find/party.json');
+        $service = $this->createService(__DIR__.'/../mocks/Find/party.json');
         $result = $service->findParty('7707083893');
 
         $this->assertEquals('145a83ab38c9ad95889a7b894ce57a97cf6f6d5f42932a71331ff18606edecc6', $result[0]->hid);
@@ -221,7 +220,7 @@ class DadataSuggestTest extends DadataServiceTest
 
     public function testFindBank(): void
     {
-        $service = $this->createService(__DIR__ . '/../mocks/Find/bank.json');
+        $service = $this->createService(__DIR__.'/../mocks/Find/bank.json');
         $result = $service->findBank('044525225');
 
         $this->assertEquals('SABRRUMM', $result[0]->swift);
@@ -232,7 +231,7 @@ class DadataSuggestTest extends DadataServiceTest
 
     public function testFindFias(): void
     {
-        $service = $this->createService(__DIR__ . '/../mocks/Find/fias.json');
+        $service = $this->createService(__DIR__.'/../mocks/Find/fias.json');
         $result = $service->findFias('77000000000268400');
 
         $this->assertEquals('г Москва, ул Снежная', $result[0]->value);
@@ -241,7 +240,7 @@ class DadataSuggestTest extends DadataServiceTest
 
     public function testFindAffiliatedParty(): void
     {
-        $service = $this->createService(__DIR__ . '/../mocks/Find/affiliatedParty.json');
+        $service = $this->createService(__DIR__.'/../mocks/Find/affiliatedParty.json');
         $result = $service->findAffiliatedParty('7736207543');
 
         $this->assertEquals('ООО "ДЗЕН.ПЛАТФОРМА"', $result[0]->value);
@@ -258,149 +257,144 @@ class DadataSuggestTest extends DadataServiceTest
                 'suggestAddress',
                 '/suggest/address',
                 'москва хабар',
-                __DIR__ . '/../mocks/Suggest/address.json',
+                __DIR__.'/../mocks/Suggest/address.json',
             ],
             [
                 'suggestParty',
                 '/suggest/party',
                 'сбербанк',
-                __DIR__ . '/../mocks/Suggest/party.json',
+                __DIR__.'/../mocks/Suggest/party.json',
             ],
             [
                 'suggestBank',
                 '/suggest/bank',
                 'сбербанк',
-                __DIR__ . '/../mocks/Suggest/bank.json',
+                __DIR__.'/../mocks/Suggest/bank.json',
             ],
             [
                 'suggestFio',
                 '/suggest/fio',
                 'Викт',
-                __DIR__ . '/../mocks/Suggest/fio.json',
+                __DIR__.'/../mocks/Suggest/fio.json',
             ],
             [
                 'suggestEmail',
                 '/suggest/email',
                 'anton@mail.ru',
-                __DIR__ . '/../mocks/Suggest/email.json',
+                __DIR__.'/../mocks/Suggest/email.json',
             ],
             [
                 'suggestFias',
                 '/suggest/fias',
                 'москва хабар',
-                __DIR__ . '/../mocks/Suggest/fias.json',
+                __DIR__.'/../mocks/Suggest/fias.json',
             ],
             [
                 'suggestFmsUnit',
                 '/suggest/fms_unit',
                 '772 053',
-                __DIR__ . '/../mocks/Suggest/fmsUnit.json',
+                __DIR__.'/../mocks/Suggest/fmsUnit.json',
             ],
             [
                 'suggestPostalUnit',
                 '/suggest/postal_unit',
                 'дежнева 2а',
-                __DIR__ . '/../mocks/Suggest/postalUnit.json',
+                __DIR__.'/../mocks/Suggest/postalUnit.json',
             ],
             [
                 'suggestFnsUnit',
                 '/suggest/fns_unit',
                 'нижнего',
-                __DIR__ . '/../mocks/Suggest/fnsUnit.json',
+                __DIR__.'/../mocks/Suggest/fnsUnit.json',
             ],
             [
                 'suggestRegionCourt',
                 '/suggest/region_court',
                 'нижний',
-                __DIR__ . '/../mocks/Suggest/regionCourt.json',
+                __DIR__.'/../mocks/Suggest/regionCourt.json',
             ],
             [
                 'suggestMetro',
                 '/suggest/metro',
                 'алек',
-                __DIR__ . '/../mocks/Suggest/metro.json',
+                __DIR__.'/../mocks/Suggest/metro.json',
             ],
             [
                 'suggestCarBrand',
                 '/suggest/car_brand',
                 'форд',
-                __DIR__ . '/../mocks/Suggest/carBrand.json',
+                __DIR__.'/../mocks/Suggest/carBrand.json',
             ],
             [
                 'suggestCountry',
                 '/suggest/country',
                 'та',
-                __DIR__ . '/../mocks/Suggest/country.json',
+                __DIR__.'/../mocks/Suggest/country.json',
             ],
             [
                 'suggestCurrency',
                 '/suggest/currency',
                 'руб',
-                __DIR__ . '/../mocks/Suggest/currency.json',
+                __DIR__.'/../mocks/Suggest/currency.json',
             ],
             [
                 'suggestOkved2',
                 '/suggest/okved2',
                 'запуск',
-                __DIR__ . '/../mocks/Suggest/okved2.json',
+                __DIR__.'/../mocks/Suggest/okved2.json',
             ],
             [
                 'suggestOkpd2',
                 '/suggest/okpd2',
                 'калоши',
-                __DIR__ . '/../mocks/Suggest/okpd2.json',
+                __DIR__.'/../mocks/Suggest/okpd2.json',
             ],
             [
                 'findAddress',
                 '/findById/address',
                 '77000000000268400',
-                __DIR__ . '/../mocks/Find/address.json',
+                __DIR__.'/../mocks/Find/address.json',
             ],
             [
                 'findPostalUnit',
                 '/findById/postal_unit',
                 '127642',
-                __DIR__ . '/../mocks/Find/postalUnit.json',
+                __DIR__.'/../mocks/Find/postalUnit.json',
             ],
             [
                 'findDelivery',
                 '/findById/delivery',
                 '3100400100000',
-                __DIR__ . '/../mocks/Find/delivery.json',
+                __DIR__.'/../mocks/Find/delivery.json',
             ],
             [
                 'findParty',
                 '/findById/party',
                 '7707083893',
-                __DIR__ . '/../mocks/Find/party.json',
+                __DIR__.'/../mocks/Find/party.json',
             ],
             [
                 'findBank',
                 '/findById/bank',
                 '044525225',
-                __DIR__ . '/../mocks/Find/bank.json',
+                __DIR__.'/../mocks/Find/bank.json',
             ],
             [
                 'findFias',
                 '/findById/fias',
                 '77000000000268400',
-                __DIR__ . '/../mocks/Find/fias.json',
+                __DIR__.'/../mocks/Find/fias.json',
             ],
             [
                 'findAffiliatedParty',
                 '/findAffiliated/party',
                 '7736207543',
-                __DIR__ . '/../mocks/Find/affiliatedParty.json',
+                __DIR__.'/../mocks/Find/affiliatedParty.json',
             ],
         ];
     }
 
     /**
-     * @param string $methodName
-     * @param string $methodUrl
-     * @param string $query
-     * @param string $filePath
-     *
      * @dataProvider suggestDataProvider
      */
     public function testSuggestRequestParams(
@@ -409,13 +403,13 @@ class DadataSuggestTest extends DadataServiceTest
         string $query,
         string $filePath
     ): void {
-        $expectedUrl = 'https://example.com/suggetions' . $methodUrl;
+        $expectedUrl = 'https://example.com/suggetions'.$methodUrl;
 
         $expectedOptions = [
             'headers' => [
                 'Content-Type' => 'application/json',
                 'Accept' => 'application/json',
-                'Authorization' => "Token token",
+                'Authorization' => 'Token token',
             ],
             'body' => json_encode(['query' => $query]),
         ];

--- a/tests/Service/DadataSuggestTest.php
+++ b/tests/Service/DadataSuggestTest.php
@@ -4,18 +4,21 @@ declare(strict_types=1);
 
 namespace Velhron\DadataBundle\Tests\Service;
 
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+use Velhron\DadataBundle\Exception\DadataException;
 use Velhron\DadataBundle\Service\DadataSuggest;
 
 class DadataSuggestTest extends DadataServiceTest
 {
     protected function createService(string $mockFilepath): DadataSuggest
     {
-        return new DadataSuggest('', '', $this->resolver, $this->getMockHttpClient($mockFilepath));
+        return new DadataSuggest('', '', $this->getMockHttpClient($mockFilepath), $this->requestFactory, $this->responseFactory);
     }
 
     public function testSuggestAddress(): void
     {
-        $service = $this->createService(__DIR__.'/../mocks/Suggest/address.json');
+        $service = $this->createService(__DIR__ . '/../mocks/Suggest/address.json');
         $result = $service->suggestAddress('москва хабар', ['count' => 10]);
 
         $this->assertCount(10, $result);
@@ -25,7 +28,7 @@ class DadataSuggestTest extends DadataServiceTest
 
     public function testSuggestParty(): void
     {
-        $service = $this->createService(__DIR__.'/../mocks/Suggest/party.json');
+        $service = $this->createService(__DIR__ . '/../mocks/Suggest/party.json');
         $result = $service->suggestParty('сбербанк', ['count' => 2]);
 
         $this->assertCount(2, $result);
@@ -43,7 +46,7 @@ class DadataSuggestTest extends DadataServiceTest
 
     public function testSuggestBank(): void
     {
-        $service = $this->createService(__DIR__.'/../mocks/Suggest/bank.json');
+        $service = $this->createService(__DIR__ . '/../mocks/Suggest/bank.json');
         $result = $service->suggestBank('сбербанк', ['count' => 2]);
 
         $this->assertCount(2, $result);
@@ -54,7 +57,7 @@ class DadataSuggestTest extends DadataServiceTest
 
     public function testSuggestFio(): void
     {
-        $service = $this->createService(__DIR__.'/../mocks/Suggest/fio.json');
+        $service = $this->createService(__DIR__ . '/../mocks/Suggest/fio.json');
         $result = $service->suggestFio('Викт');
 
         $this->assertEquals('Виктор', $result[0]->value);
@@ -63,7 +66,7 @@ class DadataSuggestTest extends DadataServiceTest
 
     public function testSuggestEmail(): void
     {
-        $service = $this->createService(__DIR__.'/../mocks/Suggest/email.json');
+        $service = $this->createService(__DIR__ . '/../mocks/Suggest/email.json');
         $result = $service->suggestEmail('anton@');
 
         $this->assertEquals('anton@mail.ru', $result[0]->value);
@@ -73,7 +76,7 @@ class DadataSuggestTest extends DadataServiceTest
 
     public function testSuggestFias(): void
     {
-        $service = $this->createService(__DIR__.'/../mocks/Suggest/fias.json');
+        $service = $this->createService(__DIR__ . '/../mocks/Suggest/fias.json');
         $result = $service->suggestFias('москва хабар', ['count' => 2]);
 
         $this->assertCount(2, $result);
@@ -83,7 +86,7 @@ class DadataSuggestTest extends DadataServiceTest
 
     public function testSuggestFmsUnit(): void
     {
-        $service = $this->createService(__DIR__.'/../mocks/Suggest/fmsUnit.json');
+        $service = $this->createService(__DIR__ . '/../mocks/Suggest/fmsUnit.json');
         $result = $service->suggestFmsUnit('772 053');
 
         $this->assertEquals('ОВД ЗЮЗИНО Г. МОСКВЫ', $result[0]->value);
@@ -93,7 +96,7 @@ class DadataSuggestTest extends DadataServiceTest
 
     public function testSuggestPostalUnit(): void
     {
-        $service = $this->createService(__DIR__.'/../mocks/Suggest/postalUnit.json');
+        $service = $this->createService(__DIR__ . '/../mocks/Suggest/postalUnit.json');
         $result = $service->suggestPostalUnit('дежнева 2а');
 
         $this->assertEquals('127642', $result[0]->value);
@@ -103,7 +106,7 @@ class DadataSuggestTest extends DadataServiceTest
 
     public function testSuggestFnsUnit(): void
     {
-        $service = $this->createService(__DIR__.'/../mocks/Suggest/fnsUnit.json');
+        $service = $this->createService(__DIR__ . '/../mocks/Suggest/fnsUnit.json');
         $result = $service->suggestFnsUnit('нижнего');
 
         $this->assertEquals('Инспекция ФНС России по Автозаводскому району г.Нижнего Новгорода', $result[0]->value);
@@ -113,7 +116,7 @@ class DadataSuggestTest extends DadataServiceTest
 
     public function testSuggestRegionCourt(): void
     {
-        $service = $this->createService(__DIR__.'/../mocks/Suggest/regionCourt.json');
+        $service = $this->createService(__DIR__ . '/../mocks/Suggest/regionCourt.json');
         $result = $service->suggestRegionCourt('нижний');
 
         $this->assertEquals('52MS0001', $result[0]->code);
@@ -122,7 +125,7 @@ class DadataSuggestTest extends DadataServiceTest
 
     public function testSuggestMetro(): void
     {
-        $service = $this->createService(__DIR__.'/../mocks/Suggest/metro.json');
+        $service = $this->createService(__DIR__ . '/../mocks/Suggest/metro.json');
         $result = $service->suggestMetro('алек');
 
         $this->assertEquals('Александровский сад', $result[0]->value);
@@ -133,7 +136,7 @@ class DadataSuggestTest extends DadataServiceTest
 
     public function testSuggestCarBrand(): void
     {
-        $service = $this->createService(__DIR__.'/../mocks/Suggest/carBrand.json');
+        $service = $this->createService(__DIR__ . '/../mocks/Suggest/carBrand.json');
         $result = $service->suggestCarBrand('форд');
 
         $this->assertEquals('Ford', $result[0]->value);
@@ -142,7 +145,7 @@ class DadataSuggestTest extends DadataServiceTest
 
     public function testSuggestCountry(): void
     {
-        $service = $this->createService(__DIR__.'/../mocks/Suggest/country.json');
+        $service = $this->createService(__DIR__ . '/../mocks/Suggest/country.json');
         $result = $service->suggestCountry('та');
 
         $this->assertEquals('Таджикистан', $result[0]->value);
@@ -151,7 +154,7 @@ class DadataSuggestTest extends DadataServiceTest
 
     public function testSuggestCurrency(): void
     {
-        $service = $this->createService(__DIR__.'/../mocks/Suggest/currency.json');
+        $service = $this->createService(__DIR__ . '/../mocks/Suggest/currency.json');
         $result = $service->suggestCurrency('руб');
 
         $this->assertEquals('Белорусский рубль', $result[0]->value);
@@ -162,7 +165,7 @@ class DadataSuggestTest extends DadataServiceTest
 
     public function testSuggestOkved2(): void
     {
-        $service = $this->createService(__DIR__.'/../mocks/Suggest/okved2.json');
+        $service = $this->createService(__DIR__ . '/../mocks/Suggest/okved2.json');
         $result = $service->suggestOkved2('запуск');
 
         $this->assertEquals('H.51.22.3', $result[0]->idx);
@@ -171,7 +174,7 @@ class DadataSuggestTest extends DadataServiceTest
 
     public function testSuggestOkpd2(): void
     {
-        $service = $this->createService(__DIR__.'/../mocks/Suggest/okpd2.json');
+        $service = $this->createService(__DIR__ . '/../mocks/Suggest/okpd2.json');
         $result = $service->suggestOkpd2('калоши');
 
         $this->assertEquals('Услуги по обрезиневанию валенок (рыбацкие калоши)', $result[0]->value);
@@ -180,7 +183,7 @@ class DadataSuggestTest extends DadataServiceTest
 
     public function testFindAddress(): void
     {
-        $service = $this->createService(__DIR__.'/../mocks/Find/address.json');
+        $service = $this->createService(__DIR__ . '/../mocks/Find/address.json');
         $result = $service->findAddress('77000000000268400');
 
         $this->assertEquals('129323, г Москва, ул Снежная', $result[0]->unrestrictedValue);
@@ -189,7 +192,7 @@ class DadataSuggestTest extends DadataServiceTest
 
     public function testFindPostalUnit(): void
     {
-        $service = $this->createService(__DIR__.'/../mocks/Find/postalUnit.json');
+        $service = $this->createService(__DIR__ . '/../mocks/Find/postalUnit.json');
         $result = $service->findPostalUnit('127642');
 
         $this->assertEquals('127642', $result[0]->postalCode);
@@ -198,7 +201,7 @@ class DadataSuggestTest extends DadataServiceTest
 
     public function testFindDelivery(): void
     {
-        $service = $this->createService(__DIR__.'/../mocks/Find/delivery.json');
+        $service = $this->createService(__DIR__ . '/../mocks/Find/delivery.json');
         $result = $service->findDelivery('3100400100000');
 
         $this->assertEquals('3100400100000', $result[0]->kladrId);
@@ -208,7 +211,7 @@ class DadataSuggestTest extends DadataServiceTest
 
     public function testFindParty(): void
     {
-        $service = $this->createService(__DIR__.'/../mocks/Find/party.json');
+        $service = $this->createService(__DIR__ . '/../mocks/Find/party.json');
         $result = $service->findParty('7707083893');
 
         $this->assertEquals('145a83ab38c9ad95889a7b894ce57a97cf6f6d5f42932a71331ff18606edecc6', $result[0]->hid);
@@ -218,7 +221,7 @@ class DadataSuggestTest extends DadataServiceTest
 
     public function testFindBank(): void
     {
-        $service = $this->createService(__DIR__.'/../mocks/Find/bank.json');
+        $service = $this->createService(__DIR__ . '/../mocks/Find/bank.json');
         $result = $service->findBank('044525225');
 
         $this->assertEquals('SABRRUMM', $result[0]->swift);
@@ -229,7 +232,7 @@ class DadataSuggestTest extends DadataServiceTest
 
     public function testFindFias(): void
     {
-        $service = $this->createService(__DIR__.'/../mocks/Find/fias.json');
+        $service = $this->createService(__DIR__ . '/../mocks/Find/fias.json');
         $result = $service->findFias('77000000000268400');
 
         $this->assertEquals('г Москва, ул Снежная', $result[0]->value);
@@ -238,7 +241,7 @@ class DadataSuggestTest extends DadataServiceTest
 
     public function testFindAffiliatedParty(): void
     {
-        $service = $this->createService(__DIR__.'/../mocks/Find/affiliatedParty.json');
+        $service = $this->createService(__DIR__ . '/../mocks/Find/affiliatedParty.json');
         $result = $service->findAffiliatedParty('7736207543');
 
         $this->assertEquals('ООО "ДЗЕН.ПЛАТФОРМА"', $result[0]->value);
@@ -246,5 +249,194 @@ class DadataSuggestTest extends DadataServiceTest
         $this->assertEquals('LEGAL', $result[0]->type);
         $this->assertEquals('7704431373', $result[0]->inn);
         $this->assertEquals('45286560000', $result[0]->okato);
+    }
+
+    public function suggestDataProvider(): array
+    {
+        return [
+            [
+                'suggestAddress',
+                '/suggest/address',
+                'москва хабар',
+                __DIR__ . '/../mocks/Suggest/address.json',
+            ],
+            [
+                'suggestParty',
+                '/suggest/party',
+                'сбербанк',
+                __DIR__ . '/../mocks/Suggest/party.json',
+            ],
+            [
+                'suggestBank',
+                '/suggest/bank',
+                'сбербанк',
+                __DIR__ . '/../mocks/Suggest/bank.json',
+            ],
+            [
+                'suggestFio',
+                '/suggest/fio',
+                'Викт',
+                __DIR__ . '/../mocks/Suggest/fio.json',
+            ],
+            [
+                'suggestEmail',
+                '/suggest/email',
+                'anton@mail.ru',
+                __DIR__ . '/../mocks/Suggest/email.json',
+            ],
+            [
+                'suggestFias',
+                '/suggest/fias',
+                'москва хабар',
+                __DIR__ . '/../mocks/Suggest/fias.json',
+            ],
+            [
+                'suggestFmsUnit',
+                '/suggest/fms_unit',
+                '772 053',
+                __DIR__ . '/../mocks/Suggest/fmsUnit.json',
+            ],
+            [
+                'suggestPostalUnit',
+                '/suggest/postal_unit',
+                'дежнева 2а',
+                __DIR__ . '/../mocks/Suggest/postalUnit.json',
+            ],
+            [
+                'suggestFnsUnit',
+                '/suggest/fns_unit',
+                'нижнего',
+                __DIR__ . '/../mocks/Suggest/fnsUnit.json',
+            ],
+            [
+                'suggestRegionCourt',
+                '/suggest/region_court',
+                'нижний',
+                __DIR__ . '/../mocks/Suggest/regionCourt.json',
+            ],
+            [
+                'suggestMetro',
+                '/suggest/metro',
+                'алек',
+                __DIR__ . '/../mocks/Suggest/metro.json',
+            ],
+            [
+                'suggestCarBrand',
+                '/suggest/car_brand',
+                'форд',
+                __DIR__ . '/../mocks/Suggest/carBrand.json',
+            ],
+            [
+                'suggestCountry',
+                '/suggest/country',
+                'та',
+                __DIR__ . '/../mocks/Suggest/country.json',
+            ],
+            [
+                'suggestCurrency',
+                '/suggest/currency',
+                'руб',
+                __DIR__ . '/../mocks/Suggest/currency.json',
+            ],
+            [
+                'suggestOkved2',
+                '/suggest/okved2',
+                'запуск',
+                __DIR__ . '/../mocks/Suggest/okved2.json',
+            ],
+            [
+                'suggestOkpd2',
+                '/suggest/okpd2',
+                'калоши',
+                __DIR__ . '/../mocks/Suggest/okpd2.json',
+            ],
+            [
+                'findAddress',
+                '/findById/address',
+                '77000000000268400',
+                __DIR__ . '/../mocks/Find/address.json',
+            ],
+            [
+                'findPostalUnit',
+                '/findById/postal_unit',
+                '127642',
+                __DIR__ . '/../mocks/Find/postalUnit.json',
+            ],
+            [
+                'findDelivery',
+                '/findById/delivery',
+                '3100400100000',
+                __DIR__ . '/../mocks/Find/delivery.json',
+            ],
+            [
+                'findParty',
+                '/findById/party',
+                '7707083893',
+                __DIR__ . '/../mocks/Find/party.json',
+            ],
+            [
+                'findBank',
+                '/findById/bank',
+                '044525225',
+                __DIR__ . '/../mocks/Find/bank.json',
+            ],
+            [
+                'findFias',
+                '/findById/fias',
+                '77000000000268400',
+                __DIR__ . '/../mocks/Find/fias.json',
+            ],
+            [
+                'findAffiliatedParty',
+                '/findAffiliated/party',
+                '7736207543',
+                __DIR__ . '/../mocks/Find/affiliatedParty.json',
+            ],
+        ];
+    }
+
+    /**
+     * @param string $methodName
+     * @param string $methodUrl
+     * @param string $query
+     * @param string $filePath
+     *
+     * @dataProvider suggestDataProvider
+     */
+    public function testSuggestRequestParams(
+        string $methodName,
+        string $methodUrl,
+        string $query,
+        string $filePath
+    ): void {
+        $expectedUrl = 'https://example.com/suggetions' . $methodUrl;
+
+        $expectedOptions = [
+            'headers' => [
+                'Content-Type' => 'application/json',
+                'Accept' => 'application/json',
+                'Authorization' => "Token token",
+            ],
+            'body' => json_encode(['query' => $query]),
+        ];
+
+        $response = $this->createMock(ResponseInterface::class);
+
+        $response
+            ->expects($this->once())
+            ->method('getContent')
+            ->willReturn(file_get_contents($filePath));
+
+        $httpClient = $this->createMock(HttpClientInterface::class);
+
+        $httpClient
+            ->expects($this->once())
+            ->method('request')
+            ->with('POST', $expectedUrl, $expectedOptions)
+            ->willReturn($response);
+
+        $service = new DadataSuggest('token', 'secret', $httpClient, $this->requestFactory, $this->responseFactory);
+
+        $service->$methodName($query);
     }
 }

--- a/tests/TestingKernel.php
+++ b/tests/TestingKernel.php
@@ -25,6 +25,6 @@ class TestingKernel extends Kernel
      */
     public function registerContainerConfiguration(LoaderInterface $loader)
     {
-        $loader->load(__DIR__.'/DependencyInjection/config.yaml');
+        $loader->load(__DIR__ . '/DependencyInjection/config.yaml');
     }
 }

--- a/tests/TestingKernel.php
+++ b/tests/TestingKernel.php
@@ -25,6 +25,6 @@ class TestingKernel extends Kernel
      */
     public function registerContainerConfiguration(LoaderInterface $loader)
     {
-        $loader->load(__DIR__ . '/DependencyInjection/config.yaml');
+        $loader->load(__DIR__.'/DependencyInjection/config.yaml');
     }
 }


### PR DESCRIPTION
Если у вас инфраструктура состоит из n-сервисов, которые обращаются в dadata, то для контроля запросов в dadata в одной точке, возможно потребуется прокси-кеш. Реализована воможность изменения дефолтных оригинальных url на url прокси-кеша