### PR TITLE
add restrict_value property to AddressRequest model

### DIFF
--- a/src/Model/Request/Suggest/AddressRequest.php
+++ b/src/Model/Request/Suggest/AddressRequest.php
@@ -35,4 +35,9 @@ class AddressRequest extends SuggestRequest
      * @var array Гранулярные подсказки по адресу
      */
     protected $to_bound;
+
+    /**
+     * @var bool Гранулярные подсказки по адресу
+     */
+    protected $restrict_value;
 }


### PR DESCRIPTION
Приветствую! Согласно [документации](https://confluence.hflabs.ru/pages/viewpage.action?pageId=222888017) необходимо передавать `restrict_value` для получения только той части, что соответствует улице.